### PR TITLE
Add cryptography with --no-binary

### DIFF
--- a/django.mk
+++ b/django.mk
@@ -15,7 +15,7 @@ REQUIREMENTS ?= requirements.txt
 SYS_PYTHON ?= python
 PIP ?= $(VE)/bin/pip
 PY_SENTINAL ?= $(VE)/sentinal
-WHEEL_VERSION ?= 0.29.0
+WHEEL_VERSION ?= 0.30.0
 VIRTUALENV ?= virtualenv.py
 SUPPORT_DIR ?= requirements/virtualenv_support/
 MAX_COMPLEXITY ?= 10
@@ -29,7 +29,7 @@ $(PY_SENTINAL): $(REQUIREMENTS) $(VIRTUALENV) $(SUPPORT_DIR)*
 	rm -rf $(VE)
 	$(SYS_PYTHON) $(VIRTUALENV) --extra-search-dir=$(SUPPORT_DIR) --never-download $(VE)
 	$(PIP) install wheel==$(WHEEL_VERSION)
-	$(PIP) install --use-wheel --no-deps --requirement $(REQUIREMENTS)
+	$(PIP) install --use-wheel --no-deps --requirement $(REQUIREMENTS) --no-binary cryptography
 	$(SYS_PYTHON) $(VIRTUALENV) --relocatable $(VE)
 	touch $@
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,6 +39,7 @@ ipdb==0.10.3
 rdflib==4.2.2
 coverage==4.5
 pyasn1==0.4.2
+cryptography==2.1.4  # pyOpenSSL
 pyOpenSSL==17.5.0
 ndg-httpsclient==0.4.4
 urllib3==1.22  # requests


### PR DESCRIPTION
Resolve a gunicorn start issue
    AttributeError: module 'lib' has no attribute 'Cryptography_HAS_SSL_ST'