### PR TITLE
Remove enum34

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ statsd==3.2.2
 pep8==1.7.1
 pyflakes==1.6.0
 mccabe==0.6.1
-enum34==1.1.6
 configparser==3.5.0
 pycodestyle==2.3.1
 flake8==3.5.0


### PR DESCRIPTION
This fixes the following error for me on python 3.6.4:
```
$ make flake8
./ve/bin/flake8 writlarge --max-complexity=10 --exclude=*/migrations/*.py
Traceback (most recent call last):
  File "./ve/bin/flake8", line 7, in <module>
    import re
  File "/usr/lib/python3.6/re.py", line 142, in <module>
    class RegexFlag(enum.IntFlag):
AttributeError: module 'enum' has no attribute 'IntFlag'
django.mk:43: recipe for target 'flake8' failed
make: *** [flake8] Error 1
```