### PR TITLE
Create archival repository flow

### DIFF
--- a/media/css/main.css
+++ b/media/css/main.css
@@ -130,3 +130,28 @@ footer li+li {
     max-width: none;
 }
 
+.archivalcollection-create .create-repository {
+    margin-top: 1.9em;
+}
+
+.archivalcollection-create .google-map {
+    width: 100%;
+    height: 300px;
+}
+
+.archivalcollection-create .step {
+    display: inline-block;
+    padding: 6px 0px 0px 2px;
+    background-color: #868e96;
+    border-radius: 50%;
+    width: 40px;
+    height: 40px;
+    text-align: center;
+    margin-right: 5px;
+    color: white;
+    font-weight: bold;
+}
+
+.archivalcollection-create .card.is-invalid .invalid-feedback {
+    display: block;
+}

--- a/media/js/src/components/gmapvue.js
+++ b/media/js/src/components/gmapvue.js
@@ -2,7 +2,7 @@
 /* exported GoogleMapVue */
 
 var GoogleMapVue = {
-    props: ['readonly'],
+    props: ['readonly', 'showplaces'],
     template: '#google-map-template',
     data: function() {
         return {
@@ -62,6 +62,9 @@ var GoogleMapVue = {
         deselectPlace: function(event) {
             this.selectedPlace = null;
         },
+        getPlace: function(event) {
+            return this.selectedPlace || this.newPin;
+        },
         geocode: function(event) {
             this.clearNewPin();
             this.selectedPlace = null;
@@ -104,10 +107,12 @@ var GoogleMapVue = {
         }
     },
     created: function() {
-        const url = WritLarge.baseUrl + 'api/site/';
-        jQuery.getJSON(url, (data) => {
-            this.places = data;
-        });
+        if (this.showplaces === 'true') {
+            const url = WritLarge.baseUrl + 'api/site/';
+            jQuery.getJSON(url, (data) => {
+                this.places = data;
+            });
+        }
     },
     mounted: function() {
         const elt = document.getElementById(this.mapName);

--- a/media/js/src/createRepository.js
+++ b/media/js/src/createRepository.js
@@ -1,0 +1,79 @@
+/* global GoogleMapVue:true, csrfSafeMethod:true */
+
+requirejs(['./common'], function() {
+    const a = ['jquery', 'utils', 'bootstrap', 'Vue', 'mapVue'];
+    requirejs(a, function($, utils, bootstrap, Vue, mapVue) {
+
+        $.ajaxSetup({
+            beforeSend: function(xhr, settings) {
+                if (!csrfSafeMethod(settings.type) && !this.crossDomain) {
+                    const token =
+                        $('meta[name="csrf-token"]').attr('content');
+                    xhr.setRequestHeader('X-CSRFToken', token);
+                }
+            }
+        });
+
+        new Vue({
+            el: '#archival-collection-create',
+            components: {
+                'google-map': GoogleMapVue,
+            },
+            data: function() {
+                return {
+                    addressError: false,
+                    titleError: false,
+                    createForm: false,
+                    collectionForm: false,
+                    repositories: []
+                };
+            },
+            methods: {
+                onCreateRepository: function(event) {
+                    const q = '.create-repository-form input[name="title"]';
+                    const title = $(q).val();
+                    const place = this.$children[0].getPlace();
+
+                    this.addressError = !place;
+                    this.titleError = !title;
+
+                    if (this.addressError || this.titleError) {
+                        return;
+                    }
+
+                    const params = {
+                        url: WritLarge.baseUrl + 'api/repository/',
+                        dataType: 'json',
+                        contentType: 'application/json',
+                        data: JSON.stringify({
+                            'title': title,
+                            'latlng': place.position.toJSON()
+                        })
+                    };
+
+                    $.post(params, (response) => {
+                        this.createForm = false;
+                        this.collectionForm = true;
+                        $('select[name="repository"]').append(
+                            $('<option></option>')
+                                .attr('value', response.id)
+                                .text(response.title));
+                        $('select[name="repository"]').val(response.id);
+                    });
+                },
+                onSelectRepository: function(event) {
+                    const value = $(event.currentTarget).val();
+                    this.createForm = value === 'create';
+                    this.collectionForm = value && value !== 'create';
+                },
+                hideForm: function(event) {
+                    this.createForm = false;
+                }
+            },
+            created: function() {
+                this.collectionForm = WritLarge.boundForm;
+            },
+        });
+    });
+});
+

--- a/writlarge/main/models.py
+++ b/writlarge/main/models.py
@@ -83,7 +83,7 @@ class LearningSite(models.Model):
 
 
 class ArchivalRepository(models.Model):
-    title = models.TextField(unique=True)
+    title = models.TextField(unique=True, verbose_name="Repository Title")
     latlng = PointField()
     description = models.TextField(null=True, blank=True)
 
@@ -105,7 +105,7 @@ class ArchivalRepository(models.Model):
 
 
 class ArchivalCollection(models.Model):
-    title = models.TextField()
+    title = models.TextField(verbose_name="Collection Title")
     repository = models.ForeignKey(ArchivalRepository,
                                    on_delete=models.CASCADE)
 

--- a/writlarge/main/serializers.py
+++ b/writlarge/main/serializers.py
@@ -38,6 +38,10 @@ class ArchivalRepositorySerializer(serializers.HyperlinkedModelSerializer):
     def get_longitude(self, obj):
         return obj.latlng.x
 
+    def validate_latlng(self, data):
+        if 'lat' in data and 'lng' in data:
+            return Point(data['lng'], data['lat'])
+
     class Meta:
         model = ArchivalRepository
         fields = ('id', 'title', 'description', 'latlng', 'notes',

--- a/writlarge/main/views.py
+++ b/writlarge/main/views.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.contrib import messages
+from django.forms.models import modelform_factory
 from django.forms.widgets import (TextInput, SelectDateWidget,
                                   CheckboxSelectMultiple)
 from django.http.response import HttpResponseRedirect
@@ -177,7 +178,6 @@ class ArchivalCollectionCreateView(LoggedInEditorMixin,
                                    ModelFormWidgetMixin,
                                    LearningSiteParamMixin,
                                    CreateView):
-
     model = ArchivalCollection
     template_name = 'main/archivalcollection_create.html'
     fields = ['repository', 'title', 'description',
@@ -189,8 +189,17 @@ class ArchivalCollectionCreateView(LoggedInEditorMixin,
         'inclusive_end_date': SelectDateWidget()
     }
 
-    def post(self, request, *args, **kwargs):
-        return CreateView.post(self, request, *args, **kwargs)
+    repository_fields = ['title', 'latlng']
+    repository_widgets = {
+        'title': TextInput,
+    }
+
+    def get_context_data(self, *args, **kwargs):
+        ctx = LearningSiteParamMixin.get_context_data(self, *args, **kwargs)
+        ctx['repository_form'] = modelform_factory(
+            ArchivalRepository, fields=self.repository_fields,
+            widgets=self.repository_widgets)
+        return ctx
 
     def get_success_url(self):
         self.object.learning_sites.add(self.parent)

--- a/writlarge/templates/main/archivalcollection_create.html
+++ b/writlarge/templates/main/archivalcollection_create.html
@@ -1,12 +1,50 @@
 {% extends 'base.html' %}
 {% load bootstrap4 %}
 {% block title %}Edit Place{% endblock %}
+{% block bodyclass %}archivalcollection-create{% endblock %}
+
+{% block client_templates %}
+<meta name="csrf-token" content="{{csrf_token}}">
+{% verbatim %}
+<script type="text/x-template" id="google-map-template">
+    <div>
+        <div class="address-bar">
+            <div class="input-group">
+                <input type="text" v-model="address"
+                    class="form-control form-control w-25"
+                    placeholder="Address"
+                    name="address" autocomplete='street-address'
+                    aria-label="Enter an address" aria-describedby="basic-addon2">
+                <div class="input-group-append">
+                    <button class="btn btn-secondary" type="button"
+                        v-on:click="geocode"><i class="fa fa-search"></i></button>
+                </div>
+            </div>
+        </div>
+        <div class="google-map" :id="mapName"></div>
+    </div>
+</script>
+{% endverbatim %}
+{% endblock %}
+
+
+{% block js %}
+    <script type="text/javascript"
+        src="//maps.google.com/maps/api/js?key={{settings.GOOGLE_MAP_API}}&libraries=places"></script>
+
+    <script>
+        WritLarge.boundForm = {% if form.data %}true{% else %} false{% endif %};
+    </script>
+
+    <script data-main="{{STATIC_URL}}js/src/createRepository.js"
+        src="{{STATIC_URL}}js/lib/require/require.js"></script>
+{% endblock %}
 
 {% block breadcrumb %}
     <nav aria-label="breadcrumb">
         <ol class="breadcrumb pb-0">
             <li class="breadcrumb-item"><a class="text-secondary" href="{% url 'site-detail-view' parent.id %}">{{parent.title}}</a></li>
-            <li class="breadcrumb-item">{% if object %}Edit{% else %}Create{% endif %} Archival Collection</li>
+            <li class="breadcrumb-item">Create Archival Collection</li>
         </ol>
     </nav>
 {% endblock %}
@@ -17,15 +55,67 @@
     <h2>
         {{parent.title}}
     </h2>
-    <h4 class="text-muted">{% if object %}Edit Archival Collection{% else %}Create Archival Collection{% endif %}</h4>
+    <h4 class="text-muted">Create Archival Collection</h4>
 </div>
 
-<div class="row">
+<div id="archival-collection-create" class="row">
     <div class="col-md-12 order-md-1">
-        <form action="." method="post">{% csrf_token %}
-            {% bootstrap_form form %}
-            <hr class="mb-4">
-            <button type="submit" class="btn btn-primary btn-block mb-4">Save</button>
+        <form action="." method="post" novalidate>{% csrf_token %}
+            <p class="lead mt-3"><span class="step">1</span> Where is the archival collection held?</p>
+            <div class="row">
+                <div class="col-md-12">
+                    <div class="form-group">
+                        <label for="id_repository">Select or create an archival repository</label>
+                        <select name="repository" v-on:change="onSelectRepository"
+                            required="required" class="form-control">
+                            {% for id, name in form.repository.field.choices %}
+                                <option value="{{ id }}"
+                                {% if form.data.repository == id|stringformat:"i" %}
+                                    selected
+                                {% endif %}>{{ name }}</option>
+                            {% endfor %}
+                            <!--  dynamically created repositories go here -->
+                            <option v-for="repo in repositories">{{repo.title}}</option>
+                            <option value="create">Create New Repository</option>
+                        </select>
+                    </div>
+                </div>
+            </div>
+            <div v-if="createForm" class="create-repository-form bg-light mb-3">
+                <div class="card">
+                    <div class="card-body bg-light" v-bind:class="{'invalid-feedback': addressError || titleError}">
+                        <div class="invalid-feedback mb-1"><strong>Oops!</strong> The title and address fields are required.</div>
+
+                        {% bootstrap_field repository_form.title %}
+
+                        <label for="id_latlng">Repository Location</label>
+                        <small class="text-muted">Search by address and select a location, or click the map to drop a marker.</small>
+                        <div>
+                            <google-map readonly="false" showplaces="false" />
+                        </div>
+                        <div class="clearfix"></div>
+                        <button class="btn btn-primary btn-block mt-3 mb-3" v-on:click.stop.prevent="onCreateRepository">
+                            Create
+                        </button>
+                        <a href="#" v-on:click.stop.prevent="hideForm"
+                            aria-expanded="true" class="btn btn-secondary btn-block">
+                            Cancel
+                        </a>
+                    </div>
+                </div>
+            </div>
+            <div v-if="collectionForm" class="create-collection-form mt-4">
+                <p class="lead"><span class="step">2</span> Add details about the archival collection</p>
+                {% bootstrap_field form.title %}
+                {% bootstrap_field form.description %}
+                {% bootstrap_field form.finding_aid_url %}
+                {% bootstrap_field form.linear_feet %}
+                {% bootstrap_field form.inclusive_start_date %}
+                {% bootstrap_field form.inclusive_end_date %}
+
+                <hr class="mb-4">
+                <button type="submit" class="btn btn-primary btn-block mb-4">Save</button>
+            </div>
         </form>
     </div>
 </div>

--- a/writlarge/templates/main/learningsite_detail.html
+++ b/writlarge/templates/main/learningsite_detail.html
@@ -63,7 +63,7 @@
             <h4 class="mb-3 text-muted">Places</h4>
             <div class="w-100 text-center">
                 <div id="map-container">
-                    <google-mini-map placeid="{{object.id}}" readonly="true" />
+                    <google-mini-map placeid="{{object.id}}" />
                 </div>
             </div>
         </div>

--- a/writlarge/templates/main/learningsite_detail.html
+++ b/writlarge/templates/main/learningsite_detail.html
@@ -63,7 +63,7 @@
             <h4 class="mb-3 text-muted">Places</h4>
             <div class="w-100 text-center">
                 <div id="map-container">
-                    <google-mini-map placeid="{{object.id}}" />
+                    <google-mini-map placeid="{{object.id}}" readonly="true" />
                 </div>
             </div>
         </div>

--- a/writlarge/templates/main/map.html
+++ b/writlarge/templates/main/map.html
@@ -1,4 +1,3 @@
-
 {% extends 'base.html' %}
 
 {% block title %}Map{% endblock %}
@@ -109,6 +108,6 @@
 
 {% block content %}
     <div id="map-container">
-        <google-map readonly="{% if is_editor %}false{% else %}true{% endif %}"/>
+        <google-map readonly="{% if is_editor %}false{% else %}true{% endif %}" showplaces="true" />
     </div>
 {% endblock %}

--- a/writlarge/urls.py
+++ b/writlarge/urls.py
@@ -73,7 +73,6 @@ urlpatterns = [
     url(r'^unlink/collection/(?P<parent>\d+)/(?P<pk>\d+)/$',
         views.ArchivalCollectionUnlinkView.as_view(),
         name='collection-unlink-view'),
-
     url(r'^create/collection/(?P<parent>\d+)/$',
         views.ArchivalCollectionCreateView.as_view(),
         name='collection-create-view'),


### PR DESCRIPTION
This PR adds the ability to create an archival repository within the create collection flow.

Background: An archival repository can house many archival collections. When a collection is created, the containing repository might not yet exist. Adding an easy-to-use, (hopefully) intuitive flow for creating the repository was a bit of a challenge, particularly as the repository needs to be physically located on a map.

Solution: Within the ArchivalCollectionCreateView, I've overridden `get_context_data` to add an ArchivalRepository form via the `modelform_factory` method. On the client-side, this form is hidden and shown based on the user's choice in the Repository select widget. Selecting an existing repository simply shows the Create Collection form. Selecting **Create New Repository** opens up the Repository form, which consists of a title field and a map.

Overall page rendering is completed via the usual Django templating and integrates form validation. Further manipulation, e.g. showing and hiding the Repository form and map integration, is completed via a Vue with the google map component used on the map page.

This was an interesting dance between clientside / serverside, and I hope not too awkward. (I chose not to go full Vue here as Django form handling is really quite nice and powerful. We'll see if that's a good decision.)

<img width="601" alt="screen shot 2018-02-28 at 9 32 19 am" src="https://user-images.githubusercontent.com/141369/36793685-09237406-1c6c-11e8-9a94-057e24825291.png">

