### PR TITLE
Extend year ranges

### DIFF
--- a/writlarge/main/views.py
+++ b/writlarge/main/views.py
@@ -81,7 +81,7 @@ class DigitalObjectCreateView(LoggedInEditorMixin,
     fields = ['file', 'description', 'datestamp', 'source_url']
     widgets = {
         'description': TextInput,
-        'datestamp': SelectDateWidget()
+        'datestamp': SelectDateWidget(years=range(1500, 2018))
     }
 
     def get_success_url(self):
@@ -98,7 +98,7 @@ class DigitalObjectUpdateView(LoggedInEditorMixin,
     fields = ['file', 'description', 'datestamp', 'source_url']
     widgets = {
         'description': TextInput,
-        'datestamp': SelectDateWidget()
+        'datestamp': SelectDateWidget(years=range(1500, 2018))
     }
 
 
@@ -185,8 +185,8 @@ class ArchivalCollectionCreateView(LoggedInEditorMixin,
               'inclusive_start_date', 'inclusive_end_date']
     widgets = {
         'title': TextInput,
-        'inclusive_start_date': SelectDateWidget(),
-        'inclusive_end_date': SelectDateWidget()
+        'inclusive_start_date': SelectDateWidget(years=range(1500, 2018)),
+        'inclusive_end_date': SelectDateWidget(years=range(1500, 2018))
     }
 
     def post(self, request, *args, **kwargs):
@@ -212,8 +212,8 @@ class ArchivalCollectionUpdateView(LoggedInEditorMixin,
               'inclusive_start_date', 'inclusive_end_date']
     widgets = {
         'title': TextInput,
-        'inclusive_start_date': SelectDateWidget(),
-        'inclusive_end_date': SelectDateWidget()
+        'inclusive_start_date': SelectDateWidget(years=range(1500, 2018)),
+        'inclusive_end_date': SelectDateWidget(years=range(1500, 2018))
     }
 
     def get_success_url(self):


### PR DESCRIPTION
This PR allows year selection from 1500 to present. This is a short-term change for demo purposes. The ExtendedDateTimeFormat will be swapped in shortly to handle the fragmentary date ranges that come along with historical data.