### PR TITLE
ExtendedDate display view

### DIFF
--- a/media/js/src/components/extendeddatevue.js
+++ b/media/js/src/components/extendeddatevue.js
@@ -59,7 +59,41 @@ var ExtendedDateVue = {
         },
         display: function(evt) {
             this.errors = this.markRequired();
-        }
+
+            if (this.errors > 0) {
+                return;
+            }
+
+            const params = {
+                url: WritLarge.baseUrl + 'date/display/',
+                data: this.asEdtf()
+            };
+
+            $.post(params, (response) => {
+                if (response.success) {
+                    this.dateDisplay = response.display;
+                } else {
+                    this.errors = 1;
+                }
+            });
+        },
+        asEdtf: function() {
+            const $el = this.el();
+            return {
+                'millenium1': $el.find(
+                    'input[name="millenium1"]').val(),
+                'century1': $el.find('input[name="century1"]').val(),
+                'decade1': $el.find('input[name="decade1"]').val(),
+                'year1': $el.find('input[name="year1"]').val(),
+                'month1': $el.find('select[name="month1"]').val(),
+                'day1': $el.find('input[name="day1"]').val(),
+                'approximate1': $el.find(
+                    'input[name="approximate1"]').prop('checked'),
+                'uncertain1': $el.find(
+                    'input[name="uncertain1"]').prop('checked'),
+                'is_range': false
+            };
+        },
     },
     mounted: function() {
         const $el = this.el();

--- a/media/js/src/editDetail.js
+++ b/media/js/src/editDetail.js
@@ -1,8 +1,19 @@
-/* global ExtendedDateVue */
+/* global ExtendedDateVue, csrfSafeMethod:true */
 
 requirejs(['./common'], function() {
     const a = ['jquery', 'utils', 'bootstrap', 'Vue', 'edtfVue'];
     requirejs(a, function($, utils, bootstrap, Vue, edtfVue) {
+
+        $.ajaxSetup({
+            beforeSend: function(xhr, settings) {
+                if (!csrfSafeMethod(settings.type) && !this.crossDomain) {
+                    const token =
+                        $('meta[name="csrf-token"]').attr('content');
+                    xhr.setRequestHeader('X-CSRFToken', token);
+                }
+            }
+        });
+
         new Vue({
             el: '#edit-detail-container',
             components: {

--- a/writlarge/main/forms.py
+++ b/writlarge/main/forms.py
@@ -6,7 +6,6 @@ from writlarge.main.models import ExtendedDate
 
 
 class ExtendedDateForm(forms.Form):
-    attr = forms.CharField(min_length=1, required=False)
     is_range = forms.BooleanField(initial=False, required=False)
 
     millenium1 = forms.IntegerField(min_value=1, max_value=2, required=False)
@@ -39,9 +38,6 @@ class ExtendedDateForm(forms.Form):
 
         self._set_errors(edt, cleaned_data)
         return cleaned_data
-
-    def get_attr(self):
-        return self.cleaned_data['attr']
 
     def get_extended_date(self):
         return ExtendedDate.objects.from_dict(self.cleaned_data)

--- a/writlarge/main/tests/test_forms.py
+++ b/writlarge/main/tests/test_forms.py
@@ -6,11 +6,6 @@ from writlarge.main.models import ExtendedDate
 
 class ExtendedDateFormTest(TestCase):
 
-    def test_get_attr(self):
-        form = ExtendedDateForm()
-        form.cleaned_data = {'attr': 'foo'}
-        self.assertEquals(form.get_attr(), 'foo')
-
     def test_clean_empty_fields(self):
         data = {
             'is_range': True,
@@ -141,7 +136,7 @@ class ExtendedDateFormTest(TestCase):
 
     def test_clean_incomplete_data(self):
         data = {
-            'approximate1': True, 'approximate2': False, 'attr': u'',
+            'approximate1': True, 'approximate2': False,
             'century1': None, 'century2': None, 'day1': None, 'day2': None,
             'decade1': None, 'decade2': None, 'is_range': False,
             'millenium1': 1, 'millenium2': None,

--- a/writlarge/main/tests/test_views.py
+++ b/writlarge/main/tests/test_views.py
@@ -414,7 +414,7 @@ class DisplayDateViewTest(TestCase):
                                     {},
                                     HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         self.assertEquals(response.status_code, 200)
-        the_json = loads(response.content)
+        the_json = loads(response.content.decode('utf-8'))
         self.assertFalse(the_json['success'])
 
         # success
@@ -424,6 +424,6 @@ class DisplayDateViewTest(TestCase):
                                      'month1': '', 'day1': ''},
                                     HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         self.assertEquals(response.status_code, 200)
-        the_json = loads(response.content)
+        the_json = loads(response.content.decode('utf-8'))
         self.assertTrue(the_json['success'])
         self.assertEquals(the_json['display'], '1673')

--- a/writlarge/main/tests/test_views.py
+++ b/writlarge/main/tests/test_views.py
@@ -397,3 +397,33 @@ class TestFootnoteViews(TestCase):
         self.assertEquals(response.status_code, 302)
         self.assertEquals(self.site.footnotes.count(), 1)
         self.assertEquals(self.site.footnotes.first().note, 'Something')
+
+
+class DisplayDateViewTest(TestCase):
+
+    def setUp(self):
+        self.site = LearningSiteFactory()
+        self.url = reverse('display-date-view')
+
+    def test_post(self):
+        # no ajax
+        self.assertEquals(self.client.post(self.url).status_code, 405)
+
+        # no_data(self):
+        response = self.client.post(self.url,
+                                    {},
+                                    HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        self.assertEquals(response.status_code, 200)
+        the_json = loads(response.content)
+        self.assertFalse(the_json['success'])
+
+        # success
+        response = self.client.post(self.url,
+                                    {'millenium1': '1', 'century1': '6',
+                                     'decade1': '7', 'year1': '3',
+                                     'month1': '', 'day1': ''},
+                                    HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        self.assertEquals(response.status_code, 200)
+        the_json = loads(response.content)
+        self.assertTrue(the_json['success'])
+        self.assertEquals(the_json['display'], '1673')

--- a/writlarge/main/views.py
+++ b/writlarge/main/views.py
@@ -6,15 +6,17 @@ from django.forms.widgets import (TextInput, SelectDateWidget,
 from django.http.response import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.urls.base import reverse
-from django.views.generic.base import TemplateView
+from django.views.generic.base import TemplateView, View
 from django.views.generic.detail import DetailView
 from django.views.generic.edit import UpdateView, CreateView, DeleteView
 from django.views.generic.list import ListView
+
 from rest_framework import viewsets
 
+from writlarge.main.forms import ExtendedDateForm
 from writlarge.main.mixins import (
     LearningSiteParamMixin, LearningSiteRelatedMixin,
-    ModelFormWidgetMixin, LoggedInEditorMixin)
+    ModelFormWidgetMixin, LoggedInEditorMixin, JSONResponseMixin)
 from writlarge.main.models import (
     LearningSite, ArchivalRepository, Place,
     DigitalObject, ArchivalCollection, Footnote)
@@ -271,6 +273,23 @@ class FootnoteDeleteView(LoggedInEditorMixin,
                          DeleteView):
     model = Footnote
     success_view = 'site-detail-view'
+
+
+class DisplayDateView(JSONResponseMixin, View):
+
+    def post(self, *args, **kwargs):
+        form = ExtendedDateForm(self.request.POST)
+
+        if not form.is_valid():
+            return self.render_to_json_response({
+                'success': False,
+                'msg': form.get_error_messages()
+            })
+        else:
+            return self.render_to_json_response({
+                'success': True,
+                'display': form.get_extended_date().__str__()
+            })
 
 
 """

--- a/writlarge/urls.py
+++ b/writlarge/urls.py
@@ -97,6 +97,10 @@ urlpatterns = [
         views.LearningSiteGalleryView.as_view(),
         name='site-gallery-view'),
 
+    url(r'^date/display/$',
+        views.DisplayDateView.as_view(),
+        name='display-date-view'),
+
     url(r'^admin/', admin.site.urls),
     url(r'^_impersonate/', include('impersonate.urls')),
     url(r'^stats/$', TemplateView.as_view(template_name="stats.html")),


### PR DESCRIPTION
Quick little view that returns a formatted date string based on the user input. Much quicker to just grab this from the server rather than reproducing the code on the clientside.

Note on the ajax setup -- I have a task to refactor that out into a common area. It's duplicating in all the views right now.

<img width="620" alt="screen shot 2018-03-02 at 7 41 40 pm" src="https://user-images.githubusercontent.com/141369/36928201-cba653f4-1e51-11e8-87f0-7a6553e053d2.png">
