### PR TITLE
Save the extended date time format

### DIFF
--- a/media/css/main.css
+++ b/media/css/main.css
@@ -221,14 +221,14 @@ input[type=number] {
     background-color: #f9f2f4;
 }
 
-.editable-edtf input[name=millenium1],
-.editable-edtf input[name=century1],
-.editable-edtf input[name=decade1],
-.editable-edtf input[name=year1] {
+.editable-edtf .millenium,
+.editable-edtf .century,
+.editable-edtf .decade,
+.editable-edtf .year {
     width: 40px !important;
 }
 
-.editable-edtf input[name=day1] {
+.editable-edtf .day1 {
     width: 40px;
     padding: .375rem .5rem;
 }

--- a/media/js/src/components/extendeddatevue.js
+++ b/media/js/src/components/extendeddatevue.js
@@ -1,12 +1,11 @@
 /* exported ExtendedDateVue */
 
 var ExtendedDateVue = {
-    props: ['id'],
+    props: ['id', 'name', 'errors'],
     template: '#edtf-template',
     data: function() {
         return {
-            dateDisplay: '',
-            errors: 0,
+            dateDisplay: ''
         };
     },
     methods: {
@@ -80,17 +79,25 @@ var ExtendedDateVue = {
         asEdtf: function() {
             const $el = this.el();
             return {
-                'millenium1': $el.find(
-                    'input[name="millenium1"]').val(),
-                'century1': $el.find('input[name="century1"]').val(),
-                'decade1': $el.find('input[name="decade1"]').val(),
-                'year1': $el.find('input[name="year1"]').val(),
-                'month1': $el.find('select[name="month1"]').val(),
-                'day1': $el.find('input[name="day1"]').val(),
-                'approximate1': $el.find(
-                    'input[name="approximate1"]').prop('checked'),
-                'uncertain1': $el.find(
-                    'input[name="uncertain1"]').prop('checked'),
+                'millenium1': $el
+                    .find('input[name="' + this.name + '-millenium1"]')
+                    .val(),
+                'century1': $el
+                    .find('input[name="' + this.name + '-century1"]').val(),
+                'decade1': $el
+                    .find('input[name="' + this.name + '-decade1"]').val(),
+                'year1': $el
+                    .find('input[name="' + this.name + '-year1"]').val(),
+                'month1': $el
+                    .find('select[name="' + this.name + '-month1"]').val(),
+                'day1': $el
+                    .find('input[name="' + this.name + '-day1"]').val(),
+                'approximate1': $el
+                    .find('input[name="' + this.name + '-approximate1"]')
+                    .prop('checked'),
+                'uncertain1': $el
+                    .find('input[name="' + this.name + '-uncertain1"]')
+                    .prop('checked'),
                 'is_range': false
             };
         },

--- a/writlarge/main/admin.py
+++ b/writlarge/main/admin.py
@@ -4,9 +4,9 @@ from django.forms.widgets import MultiWidget, TextInput
 
 from django.contrib.gis.db.models.fields import PointField
 from django.contrib.gis.geos.point import Point
-from writlarge.main.models import LearningSite, ArchivalRepository, \
-    ArchivalCollection, DigitalObject, LearningSiteCategory, \
-    ArchivalRecordFormat, Place
+from writlarge.main.models import (
+    LearningSite, ArchivalRepository, ArchivalCollection, DigitalObject,
+    LearningSiteCategory, ArchivalRecordFormat, Place, ExtendedDate)
 
 
 class LatLongWidget(MultiWidget):
@@ -74,3 +74,4 @@ class ArchivalCollectionAdmin(admin.ModelAdmin):
 admin.site.register(DigitalObject)
 admin.site.register(LearningSiteCategory)
 admin.site.register(ArchivalRecordFormat)
+admin.site.register(ExtendedDate)

--- a/writlarge/main/tests/test_forms.py
+++ b/writlarge/main/tests/test_forms.py
@@ -230,11 +230,13 @@ class LearningSiteFormTest(TestCase):
         form = LearningSiteForm(data=data)
         self.assertFalse(form.is_valid())
 
-        msg = ('millenium1: Ensure this value is less than or equal to 2.'
-               '<br />Please specify a valid date<br />')
-        self.assertEquals(form.errors['defunct'], msg)
         self.assertTrue('defunct' in form.errors)
         self.assertFalse('established' in form.errors)
+
+        self.assertTrue(
+            'Please specify a valid date' in form.errors['defunct'])
+        self.assertTrue(
+            'millenium1' in form.errors['defunct'])
 
     def test_save(self):
         site = LearningSiteFactory(defunct=None)

--- a/writlarge/main/tests/test_views.py
+++ b/writlarge/main/tests/test_views.py
@@ -415,7 +415,7 @@ class DisplayDateViewTest(TestCase):
                                     HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         self.assertEquals(response.status_code, 200)
         the_json = loads(response.content.decode('utf-8'))
-        self.assertFalse(the_json['success'])
+        self.assertTrue(the_json['success'])
 
         # success
         response = self.client.post(self.url,
@@ -427,3 +427,17 @@ class DisplayDateViewTest(TestCase):
         the_json = loads(response.content.decode('utf-8'))
         self.assertTrue(the_json['success'])
         self.assertEquals(the_json['display'], '1673')
+
+        # invalid date
+        response = self.client.post(self.url,
+                                    {'millenium1': '13', 'century1': '6',
+                                     'decade1': '7', 'year1': '3',
+                                     'month1': '', 'day1': ''},
+                                    HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        self.assertEquals(response.status_code, 200)
+        the_json = loads(response.content.decode('utf-8'))
+        self.assertFalse(the_json['success'])
+
+        msg = ('millenium1: Ensure this value is less than or equal to 2.'
+               '<br />Please specify a valid date<br />')
+        self.assertEquals(the_json['msg'], msg)

--- a/writlarge/main/tests/test_views.py
+++ b/writlarge/main/tests/test_views.py
@@ -438,6 +438,5 @@ class DisplayDateViewTest(TestCase):
         the_json = loads(response.content.decode('utf-8'))
         self.assertFalse(the_json['success'])
 
-        msg = ('millenium1: Ensure this value is less than or equal to 2.'
-               '<br />Please specify a valid date<br />')
-        self.assertEquals(the_json['msg'], msg)
+        self.assertTrue('Please specify a valid date' in the_json['msg'])
+        self.assertTrue('millenium1' in the_json['msg'])

--- a/writlarge/main/views.py
+++ b/writlarge/main/views.py
@@ -1,8 +1,7 @@
 from django.conf import settings
 from django.contrib import messages
 from django.forms.models import modelform_factory
-from django.forms.widgets import (TextInput, SelectDateWidget,
-                                  CheckboxSelectMultiple, HiddenInput)
+from django.forms.widgets import (TextInput, SelectDateWidget)
 from django.http.response import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.urls.base import reverse
@@ -10,10 +9,9 @@ from django.views.generic.base import TemplateView, View
 from django.views.generic.detail import DetailView
 from django.views.generic.edit import UpdateView, CreateView, DeleteView
 from django.views.generic.list import ListView
-
 from rest_framework import viewsets
 
-from writlarge.main.forms import ExtendedDateForm
+from writlarge.main.forms import ExtendedDateForm, LearningSiteForm
 from writlarge.main.mixins import (
     LearningSiteParamMixin, LearningSiteRelatedMixin,
     ModelFormWidgetMixin, LoggedInEditorMixin, JSONResponseMixin)
@@ -62,19 +60,9 @@ class LearningSiteDetailView(DetailView):
     model = LearningSite
 
 
-class LearningSiteUpdateView(LoggedInEditorMixin, ModelFormWidgetMixin,
-                             UpdateView):
+class LearningSiteUpdateView(LoggedInEditorMixin, UpdateView):
     model = LearningSite
-    fields = ['title', 'description', 'category', 'established', 'defunct',
-              'instructional_level', 'founder',
-              'tags', 'notes']
-    widgets = {
-        'title': TextInput,
-        'category': CheckboxSelectMultiple,
-        'established': HiddenInput,
-        'defunct': HiddenInput,
-        'instructional_level': TextInput
-    }
+    form_class = LearningSiteForm
 
 
 class DigitalObjectCreateView(LoggedInEditorMixin,

--- a/writlarge/templates/main/client/edtf_template.html
+++ b/writlarge/templates/main/client/edtf_template.html
@@ -5,26 +5,28 @@
         <div class="row">
         <div class="col-md-auto mb-2">
             <label class="d-block">Year</label>
-            <input type="number" class="form-control numeric jump" name="millenium1" min="1" max="2"
+            <input type="number" class="form-control numeric jump millenium" :name="name + '-millenium1'" min="1" max="2"
              maxlength="1" data-content="Millenium<br />Value between 1-2"
              data-toggle="popover" placeholder='-' v-on:keypress="limit"  v-on:change="display" />
-            <input type="number" class="form-control numeric jump" name="century1" min="0" max="9"
+            <input type="number" class="form-control numeric jump century" :name="name + '-century1'" min="0" max="9"
              maxlength="1" data-content="Century<br />Value between 0-9"
-             data-required="[name='millenium1']"
+             data-required=".millenium"
              data-toggle="popover" placeholder='-' v-on:keypress="limit"  v-on:change="display" />
-            <input type="number" class="form-control numeric jump" name="decade1" min="0" max="9"
+            <input type="number" class="form-control numeric jump decade"
+             :name="name + '-decade1'" min="0" max="9"
              maxlength="1" data-content="Decade<br />Value between 0-9"
-             data-required="[name='century1'],[name='millenium1']"
+             data-required=".century,.millenium"
              data-toggle="popover" placeholder='-' v-on:keypress="limit" v-on:change="display" />
-            <input type="number" class="form-control numeric jump" name="year1" min="0" max="9"
-             data-required="[name='decade1'],[name='century1'],[name='millenium1']"
+            <input type="number" class="form-control numeric jump year"
+             :name="name + '-year1'" min="0" max="9"
+             data-required=".decade,.century,.millenium"
              maxlength="1" data-content="Year<br />Value between 0-9"
              data-toggle="popover" placeholder='-' v-on:keypress="limit" v-on:change="display" />
          </div>
          <div class="col-md-auto mb-2">
             <label class="d-block">Month</label>
-            <select class="form-control" name="month1" v-on:change="display"
-             data-required="[name='year1'],[name='decade1'],[name='century1'],[name='millenium1']">
+            <select class="form-control month" :name="name + '-month1'" v-on:change="display"
+             data-required=".year,.decade,.century,.millenium">
                 <option value="">-----</option>
                 <option value="1">January</option>
                 <option value="2">February</option>
@@ -42,16 +44,16 @@
         </div>
         <div class="col-md-auto mb-2">
             <label class="d-block">Day</label>
-            <input type="number" class="form-control"
-             name="day1" maxlength="2" min="1" max="31" 
+            <input type="number" class="form-control day"
+             :name="name + '-day1'" maxlength="2" min="1" max="31" 
              data-content="Day<br />Value between 1-31"
              data-toggle="popover" placeholder='--' v-on:keypress="limit" v-on:change="display"
-             data-required="[name='month1'],[name='year1'],[name='decade1'],[name='century1'],[name='millenium1']" />
+             data-required=".month1,.year1,.decade1,.century1,.millenium1" />
         </div>
         <div class="col-md-auto mb-2">
             <label class="d-block">Traits</label>
             <div class="traits">
-                <input type="checkbox" name="approximate1" v-on:change="display" /> 
+                <input type="checkbox" class="approximate" :name="name + '-approximate1'" v-on:change="display" /> 
                     approximate
 
                 <a href="javascript:void(0);" data-toggle="tooltip" data-placement="left"
@@ -60,7 +62,7 @@
                 </a>
             </div>
             <div>
-                <input type="checkbox" name="uncertain1" v-on:change="display" /> 
+                <input type="checkbox" class="uncertain" :name="name + '-uncertain1'" v-on:change="display" /> 
                 uncertain
                 <a href="javascript:void(0);" data-toggle="tooltip" data-placement="left"
                  title="Uncertain dates indicate the information may possibly be accurate, but not definitely.">

--- a/writlarge/templates/main/learningsite_form.html
+++ b/writlarge/templates/main/learningsite_form.html
@@ -44,13 +44,13 @@
             {% bootstrap_field form.established %}
             <div class="form-group">
                 <label for="id_established">Established</label>
-                <edtf id="edtf-established"/>
+                <edtf id="edtf-established" name="established" {% if form.established.errors %}errors="1"{% endif %} />
             </div>
 
             {% bootstrap_field form.defunct %}
             <div class="form-group">
                 <label for="id_defunct">Defunct</label>
-                <edtf id="edtf-defunct" />
+                <edtf id="edtf-defunct" name="defunct" {% if form.defunct.errors %}errors="1"{% endif %}/>
             </div>
 
             {% bootstrap_field form.category %}


### PR DESCRIPTION
The LearningSite attribute update has been handled strictly through the generic UpdateView. To integrate the ExtendedDate format and the `established` & `defunct` foreign keys, a custom LearningSiteForm was added. On form clean, the edtf fields are collected and validated. On form save, the edtf foreign key is created, updated or deleted based on the incoming values.

@todo - display the resulting saved values in the view and populate the form with initial values