### PR TITLE
Learning Site Update View: populate extendeddate edit form

### DIFF
--- a/media/js/src/components/extendeddatevue.js
+++ b/media/js/src/components/extendeddatevue.js
@@ -1,16 +1,23 @@
 /* exported ExtendedDateVue */
 
 var ExtendedDateVue = {
-    props: ['id', 'name', 'errors'],
+    props: [
+        'id', 'name', 'initial-errors',
+        'millenium1', 'century1', 'decade1', 'year1',
+        'month1', 'day1', 'approximate1', 'uncertain1'],
     template: '#edtf-template',
     data: function() {
         return {
+            errors: 0,
             dateDisplay: ''
         };
     },
     methods: {
         el: function() {
             return $('#' + this.id);
+        },
+        setFocus: function() {
+            document.getElementById(this.id).scrollIntoView();
         },
         markRequired: function() {
             // If a field is not populated, and subsequent fields *are*
@@ -34,7 +41,7 @@ var ExtendedDateVue = {
             elts = elts.filter(hasValue).get().reverse();
 
             let required = 0;
-            var selector = $(elts).first().data('required');
+            let selector = $(elts).first().attr('data-required');
             $row.find(selector).not(hasValue).each(function() {
                 $(this).addClass('required');
                 required++;
@@ -65,7 +72,7 @@ var ExtendedDateVue = {
 
             const params = {
                 url: WritLarge.baseUrl + 'date/display/',
-                data: this.asEdtf()
+                data: this.toDict()
             };
 
             $.post(params, (response) => {
@@ -76,7 +83,7 @@ var ExtendedDateVue = {
                 }
             });
         },
-        asEdtf: function() {
+        toDict: function() {
             const $el = this.el();
             return {
                 'millenium1': $el
@@ -110,5 +117,36 @@ var ExtendedDateVue = {
             'placement': 'bottom'
         });
         $el.find('[data-toggle="tooltip"]').tooltip();
+
+        if (this.approximate1 === 'True') {
+            $el.find('input.approximate').prop('checked', true);
+        }
+        if (this.uncertain1 === 'True') {
+            $el.find('input.uncertain').prop('checked', true);
+        }
+        if (this.millenium1) {
+            $el.find('.millenium').val(this.millenium1);
+        }
+        if (this.century1) {
+            $el.find('.century').val(this.century1);
+        }
+        if (this.decade1) {
+            $el.find('.decade').val(this.decade1);
+        }
+        if (this.year1) {
+            $el.find('.year').val(this.year1);
+        }
+        if (this.month1) {
+            const selector = '.month option[value=' +
+                this.month1.replace(/^[0]+/g, '') + ']';
+            $el.find(selector).attr('selected','selected');
+        }
+        if (this.day1) {
+            $el.find('.day').val(this.day1);
+        }
+
+        if (this.initialErrors) {
+            this.errors = 1;
+        }
     }
 };

--- a/media/js/src/editDetail.js
+++ b/media/js/src/editDetail.js
@@ -18,6 +18,18 @@ requirejs(['./common'], function() {
             el: '#edit-detail-container',
             components: {
                 'edtf': ExtendedDateVue
+            },
+            methods: {
+                onSubmit: function(event) {
+                    for (let i=0; i < this.$children.length; i++) {
+                        if (this.$children[i].errors > 0) {
+                            this.$children[i].setFocus();
+                            event.preventDefault();
+                            event.stopPropagation();
+                            break;
+                        }
+                    }
+                }
             }
         });
     });

--- a/writlarge/main/forms.py
+++ b/writlarge/main/forms.py
@@ -33,7 +33,7 @@ class ExtendedDateForm(forms.Form):
         self.is_empty = False
 
         self.instance = self.get_extended_date()
-        display_format = self.instance.__str__()
+        display_format = self.instance and self.instance.__str__()
 
         if 'invalid' in display_format:
             self._errors['__all__'] = self.error_class([
@@ -48,7 +48,10 @@ class ExtendedDateForm(forms.Form):
         return cleaned_data
 
     def get_extended_date(self):
-        return ExtendedDate.objects.from_dict(self.cleaned_data)
+        try:
+            return ExtendedDate.objects.from_dict(self.cleaned_data)
+        except (TypeError, AttributeError):
+            return None
 
     def get_error_messages(self):
         msg = ''

--- a/writlarge/main/tests/test_models.py
+++ b/writlarge/main/tests/test_models.py
@@ -89,6 +89,35 @@ class ExtendedDateTest(TestCase):
         self.assertEquals(dt.__str__(),
                           'unknown month 17, 1980 - unknown month 18, 1997')
 
+    def test_to_dict_invalid(self):
+        dt = ExtendedDate.objects.create(edtf_format='999')
+        d = dt.to_dict()
+        self.assertEquals(len(d), 0)
+
+    def test_to_dict_partial(self):
+        dt = ExtendedDate.objects.create(edtf_format='1uuu')
+        d = dt.to_dict()
+        self.assertFalse(d['approximate1'])
+        self.assertFalse(d['uncertain1'])
+        self.assertEquals(d['millenium1'], '1')
+        self.assertIsNone(d['century1'])
+        self.assertIsNone(d['decade1'])
+        self.assertIsNone(d['year1'])
+        self.assertIsNone(d['month1'])
+        self.assertIsNone(d['day1'])
+
+    def test_to_dict_full(self):
+        dt = ExtendedDate.objects.create(edtf_format='1659-06-30?~')
+        d = dt.to_dict()
+        self.assertTrue(d['approximate1'])
+        self.assertTrue(d['uncertain1'])
+        self.assertEquals(d['millenium1'], '1')
+        self.assertEquals(d['century1'], '6')
+        self.assertEquals(d['decade1'], '5')
+        self.assertEquals(d['year1'], '9')
+        self.assertEquals(d['month1'], '06')
+        self.assertEquals(d['day1'], '30')
+
 
 class PlaceTest(TestCase):
 

--- a/writlarge/main/utils.py
+++ b/writlarge/main/utils.py
@@ -93,7 +93,7 @@ def fmt_precision(date_obj, is_interval):
 
 
 def fmt_edtf_date(edtf_obj, is_interval):
-
+    #  @todo - the model now carries this function, factor it out.
     if isinstance(edtf_obj, UncertainOrApproximate):
         date_obj = edtf_obj.date
         is_uncertain = edtf_obj.ua and edtf_obj.ua.is_uncertain

--- a/writlarge/templates/main/client/edtf_template.html
+++ b/writlarge/templates/main/client/edtf_template.html
@@ -26,7 +26,7 @@
          <div class="col-md-auto mb-2">
             <label class="d-block">Month</label>
             <select class="form-control month" :name="name + '-month1'" v-on:change="display"
-             data-required=".year,.decade,.century,.millenium">
+             data-required=".year,.decade,.century,.millenium"
                 <option value="">-----</option>
                 <option value="1">January</option>
                 <option value="2">February</option>
@@ -48,7 +48,7 @@
              :name="name + '-day1'" maxlength="2" min="1" max="31" 
              data-content="Day<br />Value between 1-31"
              data-toggle="popover" placeholder='--' v-on:keypress="limit" v-on:change="display"
-             data-required=".month1,.year1,.decade1,.century1,.millenium1" />
+             data-required=".month,.year,.decade,.century,.millenium" />
         </div>
         <div class="col-md-auto mb-2">
             <label class="d-block">Traits</label>

--- a/writlarge/templates/main/client/edtf_template.html
+++ b/writlarge/templates/main/client/edtf_template.html
@@ -26,7 +26,7 @@
          <div class="col-md-auto mb-2">
             <label class="d-block">Month</label>
             <select class="form-control month" :name="name + '-month1'" v-on:change="display"
-             data-required=".year,.decade,.century,.millenium"
+             data-required=".year,.decade,.century,.millenium">
                 <option value="">-----</option>
                 <option value="1">January</option>
                 <option value="2">February</option>

--- a/writlarge/templates/main/learningsite_form.html
+++ b/writlarge/templates/main/learningsite_form.html
@@ -27,7 +27,6 @@
 {% endblock %}
 
 {% block content %}
-
 <div class="pb-2 text-center">
     <h2>
         {{object.title}}
@@ -37,20 +36,34 @@
 
 <div id="edit-detail-container" class="row">
     <div class="col-md-12 order-md-1">
-        <form action="." method="post">{% csrf_token %}
+
+        <form action="." method="post" v-on:submit="onSubmit">{% csrf_token %}
             {% bootstrap_field form.title %}
             {% bootstrap_field form.description %}
+
 
             {% bootstrap_field form.established %}
             <div class="form-group">
                 <label for="id_established">Established</label>
-                <edtf id="edtf-established" name="established" {% if form.established.errors %}errors="1"{% endif %} />
+                <edtf id="edtf-established" name="established"
+                    {% for key, value in object.established.to_dict.items %}
+                        {% if value %}
+                            {{key}}="{{value}}"
+                        {% endif %}
+                    {% endfor %}
+                    {% if form.established.errors %}initial-errors="1"{% endif %} />
             </div>
 
             {% bootstrap_field form.defunct %}
             <div class="form-group">
                 <label for="id_defunct">Defunct</label>
-                <edtf id="edtf-defunct" name="defunct" {% if form.defunct.errors %}errors="1"{% endif %}/>
+                <edtf id="edtf-defunct" name="defunct"
+                    {% for key, value in object.defunct.to_dict.items %}
+                        {% if value %}
+                            {{key}}="{{value}}"
+                        {% endif %}
+                    {% endfor %}
+                    {% if form.defunct.errors %}errors="1"{% endif %}/>
             </div>
 
             {% bootstrap_field form.category %}


### PR DESCRIPTION
When an extended date object is populated, initialize the edtf form on the client-side. This is accomplished (reactively? debatably?), by setting initial data on the EDTF Vue component, then transferring that initial data to the rendered form.

Sidenote: I discovered the hard way that `properties`, that which is passed in the component tag, and  and `data`, that which the component holds, should not be mixed. Also, I haven't riddled out the completely correct way to set changeable input values via data properties. More research needed on that.