### PR TITLE
Basic NYPL Map Overlay integration

### DIFF
--- a/media/css/main.css
+++ b/media/css/main.css
@@ -99,8 +99,15 @@ footer li+li {
     z-index: 2000;
     margin-left: 10px;
     margin-top: 10px;
-    width: 50%;
     width: 350px;
+}
+
+.map-view .overlay-picker {
+    position: absolute;
+    z-index: 2000;
+    margin-top: 10px;
+    width: 75px;
+    right: 85px;
 }
 
 

--- a/media/js/src/components/gmapvue.js
+++ b/media/js/src/components/gmapvue.js
@@ -106,6 +106,24 @@ var GoogleMapVue = {
                     this.address = '';
                 }
             });
+        },
+        changeOverlay: function(event) {
+            const id = jQuery(event.currentTarget).data('id');
+            var overlay = new google.maps.ImageMapType({
+                getTileUrl: function(coord, zoom) {
+                    return 'http://maps.nypl.org/warper/layers/tile/' + id
+                        + '/' + zoom + '/' + coord.x + '/' + coord.y +
+                        '.png';
+                },
+                tileSize: new google.maps.Size(256, 256),
+                maxZoom: 9,
+                minZoom: 0,
+                name: 'NYPL Overlay'
+            });
+            if (this.map.overlayMapTypes.getLength() > 0) {
+                this.map.overlayMapTypes.pop();
+            }
+            this.map.overlayMapTypes.insertAt(0, overlay);
         }
     },
     created: function() {
@@ -125,7 +143,10 @@ var GoogleMapVue = {
             mapTypeControl: false,
             clickableIcons: false,
             zoom: 10,
-            center: new google.maps.LatLng(40.778572, -73.970616)
+            center: new google.maps.LatLng(40.778572, -73.970616),
+            fullscreenControlOptions: {
+                position: google.maps.ControlPosition.RIGHT_BOTTOM
+            }
         });
         if (!this.isReadOnly()) {
             this.map.addListener('click', (ev) => {

--- a/writlarge/templates/main/client/map_template.html
+++ b/writlarge/templates/main/client/map_template.html
@@ -13,6 +13,21 @@
                 </div>
             </div>
         </div>
+        <div class="overlay-picker">
+            <div class="btn-group" role="group">
+            <button id="overlays" type="button" class="btn btn-secondary dropdown-toggle"
+                data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <i class="fa fa-clock-o" aria-hidden="true"></i> Time Travel
+            </button>
+            <div class="dropdown-menu" aria-labelledby="btnGroupDrop1">
+                <a class="dropdown-item" href="#" data-id="864" v-on:click="changeOverlay">1885</a>
+                <a class="dropdown-item" href="#" data-id="1090" v-on:click="changeOverlay">1891</a>
+                <a class="dropdown-item" href="#" data-id="871" v-on:click="changeOverlay">1911</a>
+                <a class="dropdown-item" href="#" data-id="862" v-on:click="changeOverlay">1916</a>
+                <a class="dropdown-item" href="#" data-id="1453" v-on:click="changeOverlay">1956</a>
+            </div>
+            </div>
+        </div>
         <div class="google-map" :id="mapName"></div>
         <div v-if="newPin" class="row">
             <div class="col-12">


### PR DESCRIPTION
This is a very basic integration of historical map tiles from the NYPL's Map Warper tool. All maps are rectified and available to use under Creative Commons CC0 1.0 Universal Public Domain Dedication via the NYPL Map Warper tool.

@todo - 
* Change the ButtonGroup into a slider. The current implementation is not responsive.
* Consider how these tiles are stored. Do we need to serve them off our own servers? Unsure
* Add proper credits & citations.