### PR TITLE
Map interface: don't drop pin on search

### DIFF
--- a/media/js/src/components/gmapvue.js
+++ b/media/js/src/components/gmapvue.js
@@ -97,16 +97,6 @@ var GoogleMapVue = {
                 if (responses && responses.length > 0) {
                     this.address = responses[0].formatted_address;
                     const position = responses[0].geometry.location;
-                    if (!this.isReadOnly()) {
-                        if (this.newPin) {
-                            this.newPin.setMap(null);
-                        }
-
-                        this.newPin = new google.maps.Marker({
-                            position: position,
-                            map: this.map
-                        });
-                    }
 
                     // zoom in on the location, but not too far
                     this.bounds = new google.maps.LatLngBounds();


### PR DESCRIPTION
Retain the "zoom in" behavior, but don't drop a pin by default.