### PR TITLE
Speed up map render

### DIFF
--- a/writlarge/main/views.py
+++ b/writlarge/main/views.py
@@ -373,8 +373,13 @@ class ArchivalRepositoryViewSet(viewsets.ModelViewSet):
 
 
 class LearningSiteViewSet(viewsets.ModelViewSet):
-    queryset = LearningSite.objects.all().order_by('-modified_at')
     serializer_class = LearningSiteSerializer
+
+    def get_queryset(self):
+        return LearningSite.objects.all().select_related(
+            'created_by', 'modified_by').prefetch_related(
+            'place', 'category', 'digital_object', 'children',
+            'site_one', 'site_two', 'tags').order_by('-modified_at')
 
 
 class PlaceViewSet(viewsets.ModelViewSet):

--- a/writlarge/urls.py
+++ b/writlarge/urls.py
@@ -24,7 +24,7 @@ if hasattr(settings, 'CAS_BASE'):
 
 
 router = routers.DefaultRouter()
-router.register(r'site', views.LearningSiteViewSet)
+router.register(r'site', views.LearningSiteViewSet, base_name='site')
 router.register(r'repository', views.ArchivalRepositoryViewSet)
 router.register(r'place', views.PlaceViewSet)
 


### PR DESCRIPTION
The underlying slowness caused by the LearningSite rest api. Optimized the object retrieval via the usual select_related & prefetch_related.