### PR TITLE
Add django-smtp-ssl dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -111,4 +111,6 @@ pbr==4.1.0 # bandit
 PyYAML==3.12 # bandit
 stevedore==1.28.0  # bandit
 bandit==1.4.0
+
+django-smtp-ssl==1.0
 django-contact-us==0.4.1


### PR DESCRIPTION
This library acts as a shim for the AWS SES email. This backend is specified in local_settings.py along with other settings to enable the service.