### PR TITLE
 Convert a suggested collection into a real collection

### DIFF
--- a/writlarge/main/admin.py
+++ b/writlarge/main/admin.py
@@ -94,7 +94,7 @@ class ArchivalCollectionSuggestionAdmin(admin.ModelAdmin):
                                kwargs={'pk': coll.id})
                 msgs.append(created.format(link, obj.collection_title))
 
-        self.message_user(request, mark_safe('<br />'.join(msgs)))
+        self.message_user(request, mark_safe('<br />'.join(msgs)))  # nosec
 
     convert_suggested_collection.short_description = \
         "Convert to ArchivalCollection"

--- a/writlarge/main/tests/factories.py
+++ b/writlarge/main/tests/factories.py
@@ -7,7 +7,8 @@ from factory.fuzzy import BaseFuzzyAttribute
 
 from writlarge.main.models import (
     LearningSiteCategory, LearningSite, LearningSiteRelationship,
-    ExtendedDate, ArchivalRepository, Place, ArchivalCollection, Footnote)
+    ExtendedDate, ArchivalRepository, Place, ArchivalCollection, Footnote,
+    ArchivalCollectionSuggestion)
 
 
 class FuzzyPoint(BaseFuzzyAttribute):
@@ -104,6 +105,28 @@ class ArchivalCollectionFactory(factory.DjangoModelFactory):
 
     collection_title = factory.Sequence(lambda n: "collection%03d" % n)
     repository = factory.SubFactory(ArchivalRepositoryFactory)
+
+
+class ArchivalCollectionSuggestionFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = ArchivalCollectionSuggestion
+
+    repository_title = factory.Sequence(lambda n: "repository%03d" % n)
+    collection_title = factory.Sequence(lambda n: "collection%03d" % n)
+
+    person = 'Elizabeth B. Drewry'
+    person_title = 'Director of the Roosevelt Library'
+    email = 'edrewry@rooseveltlibrary.org'
+
+    latlng = FuzzyPoint()
+    title = 'Hyde Park, NY'
+
+    description = 'Sample description'
+    finding_aid_url = 'https://fdrlibrary.org/finding-aids'
+    linear_feet = 3
+
+    inclusive_start = factory.SubFactory(ExtendedDateFactory)
+    inclusive_end = factory.SubFactory(ExtendedDateFactory)
 
 
 class FootnoteFactory(factory.DjangoModelFactory):

--- a/writlarge/templates/admin/main/archivalcollectionsuggestion/change_form.html
+++ b/writlarge/templates/admin/main/archivalcollectionsuggestion/change_form.html
@@ -1,0 +1,17 @@
+{% extends "admin/change_form.html" %}
+{% load i18n admin_urls static admin_modify %}
+
+{% block object-tools-items %}
+    {{ block.super }}
+    {% if original %}
+    <li>
+        <form method="post" action="/admin/main/archivalcollectionsuggestion/">
+            {% csrf_token %}
+            <input type="hidden" name="action" value="convert_suggested_collection" />
+            <input type="hidden" name="_selected_action" value="{{original.pk}}" />
+            <input type="hidden" name="select_across" value="0" class="select-across">
+            <button type="submit" class="button" style="padding: 5px; margin-top: -2px;" title="{% trans "Convert to Archival Collection" %}" name="index" value="0">{% trans "Convert to Archival Collection" %}</button>
+        </form>
+    </li>
+    {% endif %}
+{% endblock %}


### PR DESCRIPTION
Leveraging the [Django admin actions](https://docs.djangoproject.com/en/2.0/ref/contrib/admin/actions/) logic to allow administrators to convert a suggested archival collection into a real archival collection that is displayed on the site.

Test data references [Elizabeth B. Drewry](https://en.wikipedia.org/wiki/Elizabeth_B._Drewry), an American archivist, recognized for her long career at the National Archives and the Franklin D. Roosevelt Presidential Library and Museum. She was the first woman to become the head of a Presidential library.