### PR TITLE
Location selection tweaks

### DIFF
--- a/media/js/src/components/gmapvue.js
+++ b/media/js/src/components/gmapvue.js
@@ -3,7 +3,7 @@
 
 var GoogleMapVue = {
     props: ['readonly', 'showplaces', 'latitude',
-        'longitude', 'title', 'icon'],
+        'longitude', 'title', 'icon', 'autodrop'],
     template: '#google-map-template',
     data: function() {
         return {
@@ -104,6 +104,16 @@ var GoogleMapVue = {
                     this.bounds.extend(position);
                     this.bounds = enlargeBounds(this.bounds);
                     this.map.fitBounds(this.bounds);
+
+                    if (this.autodrop === 'true') {
+                        const marker = new google.maps.Marker({
+                            position: position,
+                            map: this.map,
+                            icon: WritLarge.staticUrl +
+                                'png/pin-' + this.icon + '.png'
+                        });
+                        this.newPin = marker;
+                    }
                 }
             });
         },

--- a/writlarge/templates/main/archivalcollection_create.html
+++ b/writlarge/templates/main/archivalcollection_create.html
@@ -50,7 +50,7 @@
 
 <div id="archival-collection-create" class="row">
     <div class="col-md-12 order-md-1">
-        <form action="." method="post" novalidate v-on:submit="onSubmit">{% csrf_token %}
+        <form action="." method="post" novalidate v-on:keydown.enter.prevent  v-on:submit="onSubmit">{% csrf_token %}
             <p class="lead mt-3"><span class="step">1</span> Where is the archival collection held?</p>
             <div class="row">
                 <div class="col-md-12">
@@ -82,7 +82,7 @@
                         <label>Repository Location</label>
                         <small class="text-muted">Search by address or click the map to drop a marker.</small>
                         <div>
-                            <google-map readonly="false" showplaces="false" icon="archive" />
+                            <google-map readonly="false" showplaces="false" icon="archive" autodrop="true" />
                         </div>
                         <div class="clearfix"></div>
                         <button class="btn btn-primary btn-block mt-3 mb-2" v-on:click.stop.prevent="onCreateRepository">

--- a/writlarge/templates/main/archivalcollection_suggest.html
+++ b/writlarge/templates/main/archivalcollection_suggest.html
@@ -29,21 +29,24 @@
 
 <div id="edit-detail-container" class="row">
     <div class="col-md-12 order-md-1">
-        <form action="." method="post" novalidate v-on:submit="onSubmit">{% csrf_token %}
+        <form action="." method="post" novalidate v-on:keydown.enter.prevent v-on:submit="onSubmit">{% csrf_token %}
             <p class="lead mt-3"><span class="step">1</span> Tell us about yourself</p>
             {% bootstrap_field form.person_title show_label=False %}
             {% bootstrap_field form.person show_label=False %}
             {% bootstrap_field form.email show_label=False %}
 
             <p class="lead mt-4"><span class="step">2</span> Where is the archival collection held?</p>
-            {% if form.latlng.errors %}
-                <div class="text-danger">
-                    Search by address and select a location, or click the map to drop a marker.
-                </div>
-            {% endif %}
              <div class="mb-4">
-                <p class="text-muted">Search by address and select a location, or click the map to drop a marker.</p>
-                <google-map readonly="false" showplaces="false" icon="archive" />
+                <p class="{% if form.latlng.errors %}text-danger{% else %}text-muted{% endif %}">
+                    Search by address or click the map to drop a marker.
+                </p>
+                <google-map readonly="false" showplaces="false" icon="archive" autodrop="true"
+                    {% if form.data.title %}
+                        title="{{form.data.title}}"
+                        latitude="{{form.cleaned_data.latlng.coords.1}}"
+                        longitude="{{form.cleaned_data.latlng.coords.0}}"
+                    {% endif %}
+                    />
             </div>
 
             <div class="mt-4">

--- a/writlarge/templates/main/client/pick_location_template.html
+++ b/writlarge/templates/main/client/pick_location_template.html
@@ -9,7 +9,8 @@
                     class="form-control form-control w-25"
                     placeholder="Address"
                     name="address" autocomplete='street-address'
-                    aria-label="Enter an address" aria-describedby="basic-addon2">
+                    aria-label="Enter an address" aria-describedby="basic-addon2"
+                    v-on:keyup.enter.prevent="geocode">
                 <div class="input-group-append">
                     <button class="btn btn-secondary" type="button"
                         v-on:click="geocode"><i class="fa fa-search"></i></button>

--- a/writlarge/templates/main/place_form.html
+++ b/writlarge/templates/main/place_form.html
@@ -35,7 +35,7 @@
 
 <div id="edit-detail-container" class="row">
     <div class="col-md-12 order-md-1">
-        <form action="." method="post" enctype="multipart/form-data" v-on:submit="onSubmit" onkeypress="return event.keyCode != 13;">
+        <form action="." method="post" enctype="multipart/form-data" v-on:keydown.enter.prevent v-on:submit="onSubmit" onkeypress="return event.keyCode != 13;">
             {% csrf_token %}
             {% if form.title.errors or form.latlng.errors %}
                 <div class="text-danger">
@@ -44,7 +44,7 @@
             {% endif %}
              <div class="mb-4">
                 <label>Location</label>
-                <google-map readonly="false" showplaces="false" icon="{{parent.category.first.group}}"
+                <google-map readonly="false" showplaces="false" icon="{{parent.category.first.group}}" autodrop="true"
                     {% if object %}title="{{object.title}}" latitude="{{object.latitude}}" longitude="{{object.longitude}}"{% endif %} />
             </div>
 


### PR DESCRIPTION
* When searching for a location, a user may enter an address and hit enter to activate a search within the map. Update behavior to route the enter key to the map search rather than submitting the form.
* Add an "autodrop" property to automatically drop a pin on address search.

Location selection occurs for Place create/edit, Archival Repository create/edit, Archival Collection suggestion create.