### PR TITLE
Map view: differentiate selected location

### DIFF
--- a/media/js/src/components/gmapvue.js
+++ b/media/js/src/components/gmapvue.js
@@ -34,6 +34,19 @@ var GoogleMapVue = {
         isReadOnly: function() {
             return this.readonly === 'true';
         },
+        siteIconUrl: function(site) {
+            const icon = site.category.length > 0 ?
+                site.category[0].group : 'other';
+            return WritLarge.staticUrl + 'png/pin-' + icon + '.png';
+        },
+        clearSelectedPlace: function() {
+            if (!this.selectedPlace) {
+                return;
+            }
+            const url = this.siteIconUrl(this.selectedPlace);
+            this.selectedPlace.marker.setIcon(url);
+            this.selectedPlace = null;
+        },
         clearNewPin: function(event) {
             if (this.newPin) {
                 this.newPin.setMap(null);
@@ -44,12 +57,11 @@ var GoogleMapVue = {
         },
         dropPin: function(event) {
             this.clearNewPin();
-            this.selectedPlace = null;
+            this.clearSelectedPlace();
 
             this.newPin = new google.maps.Marker({
                 position: event.latLng,
-                map: this.map,
-                icon: WritLarge.staticUrl + 'png/pin-' + this.icon + '.png'
+                map: this.map
             });
 
             this.reverseGeocode(this.newPin);
@@ -78,9 +90,6 @@ var GoogleMapVue = {
                 this.newPin = null;
                 this.newTitle = '';
             });
-        },
-        deselectPlace: function(event) {
-            this.selectedPlace = null;
         },
         getAddress: function(event) {
             return this.address;
@@ -208,17 +217,19 @@ var GoogleMapVue = {
             if (!site.marker) {
                 const position = new google.maps.LatLng(
                     site.place[0].latitude, site.place[0].longitude);
-                const icon = site.category.length > 0 ?
-                    site.category[0].group : 'other';
                 const marker = new google.maps.Marker({
                     position: position,
                     map: this.map,
-                    icon: WritLarge.staticUrl + 'png/pin-' + icon + '.png'
+                    icon: this.siteIconUrl(site)
                 });
                 site.marker = marker;
-                google.maps.event.addListener(marker, 'click', (ev) => {
+                google.maps.event.addListener(marker, 'click', (e) => {
                     this.clearNewPin();
+                    this.clearSelectedPlace();
                     this.selectedPlace = site;
+
+                    // set to default red icon
+                    marker.setIcon();
                 });
             }
         });

--- a/writlarge/templates/main/client/map_template.html
+++ b/writlarge/templates/main/client/map_template.html
@@ -58,7 +58,7 @@
         <div v-if="selectedPlace" class="pin-place-detail">
            <div class="pin-place-header d-flex justify-content-between">
                 <h5>{{selectedPlace.title}}</h5>
-                <button type="button" class="close align-self-baseline" aria-label="Close" v-on:click.stop.prevent="deselectPlace"><span aria-hidden="true">×</span></button>
+                <button type="button" class="close align-self-baseline" aria-label="Close" v-on:click.stop.prevent="clearSelectedPlace"><span aria-hidden="true">×</span></button>
             </div>
             <div v-if="selectedPlace.digital_object.length" class="pin-place-thumbnail clearfix">
                 <div v-if="selectedPlace.digital_object[0].file" class="thumbnail-bg" v-bind:style="{ backgroundImage: 'url(' + selectedPlace.digital_object[0].file + ')' }"></div>
@@ -68,7 +68,7 @@
                 <p class="my-0">Can you add more detail to this location?</p>
                 <div class="row mt-4 mt-md-3">
                     <div class="col">
-                        <button class="w-100 btn btn-sm btn-secondary" v-on:click.stop.prevent="deselectPlace">
+                        <button class="w-100 btn btn-sm btn-secondary" v-on:click.stop.prevent="clearSelectedPlace">
                             Later
                         </button>
                     </div>


### PR DESCRIPTION
When a user clicks a site of teaching & learning or drops a pin in a new location, display the default red icon marker to indicate the location is selected.