### PR TITLE
Add advanced search options

### DIFF
--- a/writlarge/main/tests/test_mixins.py
+++ b/writlarge/main/tests/test_mixins.py
@@ -1,0 +1,76 @@
+from django.test.client import RequestFactory
+from django.test.testcases import TestCase
+
+from writlarge.main.mixins import LearningSiteSearchMixin
+from writlarge.main.models import LearningSite
+from writlarge.main.tests.factories import LearningSiteFactory
+
+
+class LearningSiteSearchMixinTest(TestCase):
+
+    def setUp(self):
+        self.site1 = LearningSiteFactory(title='Site Alpha')
+        self.site2 = LearningSiteFactory(title='Site Beta')
+        self.site3 = LearningSiteFactory(title='Site Gamma')
+        self.site3.tags.add('red')
+
+    def test_filter(self):
+        mixin = LearningSiteSearchMixin()
+        mixin.request = RequestFactory().get('/', {'q': 'Alpha'})
+        qs = mixin.filter(LearningSite.objects.all())
+        self.assertEquals(qs.count(), 1)
+        self.assertEquals(qs.first(), self.site1)
+
+    def test_process_query(self):
+        mixin = LearningSiteSearchMixin()
+
+        all = LearningSite.objects.all()
+        qs = mixin._process_query(qs=all, q='site')
+        self.assertEquals(qs.count(), 3)
+
+        qs = mixin._process_query(qs=all, q='Alpha')
+        self.assertEquals(qs.count(), 1)
+        self.assertEquals(qs.first(), self.site1)
+
+        qs = mixin._process_query(
+            qs=all, q='category:{}'.format(self.site2.category.first().name))
+        self.assertEquals(qs.count(), 1)
+        self.assertEquals(qs.first(), self.site2)
+
+        qs = mixin._process_query(qs=all, q='tag:red')
+        self.assertEquals(qs.count(), 1)
+        self.assertEquals(qs.first(), self.site3)
+
+    def test_tokenize(self):
+        mixin = LearningSiteSearchMixin()
+
+        t = mixin._tokenize('some search terms')
+        self.assertEquals(next(t), ('STRING', 'some'))
+        self.assertEquals(next(t), ('STRING', 'search'))
+        self.assertEquals(next(t), ('STRING', 'terms'))
+
+        t = mixin._tokenize('"abc"')
+        self.assertEquals(next(t), ('STRING', 'abc'))
+
+        t = mixin._tokenize('"abc" "def"')
+        self.assertEquals(next(t), ('STRING', 'abc'))
+        self.assertEquals(next(t), ('STRING', 'def'))
+
+        t = mixin._tokenize('category:foo')
+        self.assertEquals(next(t), ('CATEGORY', 'foo'))
+
+        t = mixin._tokenize('tag:bar')
+        self.assertEquals(next(t), ('TAG', 'bar'))
+
+        t = mixin._tokenize('category:foo baz')
+        self.assertEquals(next(t), ('CATEGORY', 'foo'))
+        self.assertEquals(next(t), ('STRING', 'baz'))
+
+        q = 'some "a b" search category:foo tag:xyz terms'
+        t = mixin._tokenize(q)
+        self.assertEquals(next(t), ('STRING', 'some'))
+        self.assertEquals(next(t), ('STRING', 'a b'))
+        self.assertEquals(next(t), ('STRING', 'search'))
+        self.assertEquals(next(t), ('CATEGORY', 'foo'))
+        self.assertEquals(next(t), ('TAG', 'xyz'))
+        self.assertEquals(next(t), ('STRING', 'terms'))

--- a/writlarge/main/tests/test_utils.py
+++ b/writlarge/main/tests/test_utils.py
@@ -1,4 +1,5 @@
 from django.test.testcases import TestCase
+
 from writlarge.main.utils import filter_fields
 
 

--- a/writlarge/main/tests/test_views.py
+++ b/writlarge/main/tests/test_views.py
@@ -669,17 +669,6 @@ class SearchViewTest(TestCase):
         self.assertEquals(
             response.context['base_url'], '/search/?q=bar&page=')
 
-    def test_search_by_creator(self):
-        url = "{}?q={}".format(reverse('search-view'), self.user.username)
-
-        response = self.client.get(url)
-        self.assertEquals(response.status_code, 200)
-        self.assertEquals(len(response.context['page_obj'].object_list), 1)
-        self.assertEquals(
-            response.context['page_obj'].object_list[0], self.site1)
-
-        self.assertEquals(response.context['query'], self.user.username)
-
     def test_empty_search(self):
         url = reverse('search-view')
 
@@ -743,3 +732,15 @@ class ConnectionDeleteViewTest(TestCase):
         response = self.client.post(url)
         self.assertEquals(response.status_code, 302)
         self.assertTrue(self.site not in self.parent.associates())
+
+
+class LearningSiteViewSetTest(TestCase):
+
+    def test_get(self):
+        site1 = LearningSiteFactory(title='Site Alpha')
+        url = "/api/site/?q=Alpha"
+        response = self.client.get(url)
+        self.assertEquals(response.status_code, 200)
+        the_json = loads(response.content)
+        self.assertEquals(len(the_json), 1)
+        self.assertEquals(the_json[0]['id'], site1.id)

--- a/writlarge/main/tests/test_views.py
+++ b/writlarge/main/tests/test_views.py
@@ -741,6 +741,6 @@ class LearningSiteViewSetTest(TestCase):
         url = "/api/site/?q=Alpha"
         response = self.client.get(url)
         self.assertEquals(response.status_code, 200)
-        the_json = loads(response.content)
+        the_json = loads(response.content.decode('utf-8'))
         self.assertEquals(len(the_json), 1)
         self.assertEquals(the_json[0]['id'], site1.id)

--- a/writlarge/templates/main/search.html
+++ b/writlarge/templates/main/search.html
@@ -19,7 +19,7 @@
                 <span class="input-group-text">Search</span>
             </div>
             <input type="text" class="form-control" name="q"
-                placeholder="by title, author" value="{{query}}" />
+                placeholder="by title" value="{{query}}" />
             {% if query %}
             <span class="input-group-btn">
                 <a class="btn btn-light btn-clear-search" href="{% url 'search-view' %}">


### PR DESCRIPTION
* Implement a [basic regex tokenizer](https://docs.python.org/3/library/re.html#writing-a-tokenizer) to support searching by quoted strings and prefixes (`category:`, `tag:`) in addition to regular strings.
* Hook up the additional search options to the `LearningSite` REST api and to the SearchListView.
* Remove the Search by author feature.