### PR TITLE
MapView: Add min/max years

### DIFF
--- a/writlarge/main/models.py
+++ b/writlarge/main/models.py
@@ -102,6 +102,16 @@ class ExtendedDate(models.Model):
 
         return d
 
+    def get_year(self):
+        # As Writ Large does not use ranges, simply return the lower year
+        if self.is_unknown():
+            return
+
+        (lower, upper) = self.wrap()
+        dt = lower.start_date()
+        if dt and dt.year:
+            return dt.year
+
 
 class Footnote(models.Model):
     ordinal = models.IntegerField(default=1)
@@ -327,6 +337,12 @@ class LearningSite(models.Model):
     def group(self):
         category = self.category.first()
         return category.group if category else 'other'
+
+    def get_min_year(self):
+        if self.established:
+            return self.established.get_year()
+        if self.defunct:
+            return self.defunct.get_year()
 
 
 class LearningSiteRelationship(models.Model):

--- a/writlarge/main/models.py
+++ b/writlarge/main/models.py
@@ -344,6 +344,12 @@ class LearningSite(models.Model):
         if self.defunct:
             return self.defunct.get_year()
 
+    def get_max_year(self):
+        if self.defunct:
+            return self.defunct.get_year()
+        if self.established:
+            return self.established.get_year()
+
 
 class LearningSiteRelationship(models.Model):
     site_one = models.ForeignKey(

--- a/writlarge/main/serializers.py
+++ b/writlarge/main/serializers.py
@@ -73,6 +73,8 @@ class LearningSiteSerializer(serializers.HyperlinkedModelSerializer):
     place = PlaceSerializer(many=True)
     tags = StringListField(read_only=True)
     family = serializers.SerializerMethodField(read_only=True)
+    min_year = serializers.SerializerMethodField(read_only=True)
+    max_year = serializers.SerializerMethodField(read_only=True)
 
     def get_family(self, obj):
         family = []
@@ -85,12 +87,18 @@ class LearningSiteSerializer(serializers.HyperlinkedModelSerializer):
             })
         return family
 
+    def get_min_year(self, obj):
+        return obj.get_min_year()
+
+    def get_max_year(self, obj):
+        return obj.get_max_year()
+
     class Meta:
         model = LearningSite
         fields = ('id', 'title', 'place', 'notes', 'category',
                   'digital_object', 'verified', 'verified_modified_at',
                   'empty', 'tags', 'created_at', 'modified_at',
-                  'family')
+                  'family', 'min_year', 'max_year')
 
     def create(self, validated_data):
         place_data = validated_data.pop('place')

--- a/writlarge/main/tests/test_models.py
+++ b/writlarge/main/tests/test_models.py
@@ -208,19 +208,21 @@ class LearningSiteTest(TestCase):
         site = LearningSiteFactory()
         self.assertEquals(site.group(), 'school')
 
-    def get_test_min_year(self):
+    def test_get_min_max_year(self):
         site = LearningSiteFactory()
         self.assertEquals(site.get_min_year(), 1984)
+        self.assertEquals(site.get_max_year(), 1984)
 
-        site.established = None
-        site.defunct = None
-        site.save()
-        self.assertEquals(site.get_min_year(), 0)
+        site = LearningSiteFactory(established=None, defunct=None)
+        self.assertIsNone(site.get_min_year())
+        self.assertIsNone(site.get_max_year())
 
+        site = LearningSiteFactory()
         dt = ExtendedDate.objects.create(edtf_format='2018')
         site.defunct = dt
         site.save()
-        self.assertEquals(site.get_min_year(), 2018)
+        self.assertEquals(site.get_min_year(), 1984)
+        self.assertEquals(site.get_max_year(), 2018)
 
 
 class ArchivalCollectionSuggestionTest(TestCase):

--- a/writlarge/main/tests/test_models.py
+++ b/writlarge/main/tests/test_models.py
@@ -132,6 +132,22 @@ class ExtendedDateTest(TestCase):
         self.assertEquals(d['month1'], '06')
         self.assertEquals(d['day1'], '30')
 
+    def test_get_year(self):
+        dt = ExtendedDate.objects.create(edtf_format='1659-06-30?~')
+        self.assertEquals(dt.get_year(), 1659)
+
+        dt = ExtendedDate.objects.create(edtf_format='2uuu')
+        self.assertEquals(dt.get_year(), 2000)
+
+        dt = ExtendedDate.objects.create(edtf_format='14uu')
+        self.assertEquals(dt.get_year(), 1400)
+
+        dt = ExtendedDate.objects.create(edtf_format='192u')
+        self.assertEquals(dt.get_year(), 1920)
+
+        dt = ExtendedDate.objects.create(edtf_format='unknown')
+        self.assertIsNone(dt.get_year())
+
 
 class PlaceTest(TestCase):
 
@@ -191,6 +207,20 @@ class LearningSiteTest(TestCase):
 
         site = LearningSiteFactory()
         self.assertEquals(site.group(), 'school')
+
+    def get_test_min_year(self):
+        site = LearningSiteFactory()
+        self.assertEquals(site.get_min_year(), 1984)
+
+        site.established = None
+        site.defunct = None
+        site.save()
+        self.assertEquals(site.get_min_year(), 0)
+
+        dt = ExtendedDate.objects.create(edtf_format='2018')
+        site.defunct = dt
+        site.save()
+        self.assertEquals(site.get_min_year(), 2018)
 
 
 class ArchivalCollectionSuggestionTest(TestCase):

--- a/writlarge/main/tests/test_views.py
+++ b/writlarge/main/tests/test_views.py
@@ -12,9 +12,9 @@ from writlarge.main.serializers import LearningSiteSerializer
 from writlarge.main.tests.factories import (
     UserFactory, LearningSiteFactory, ArchivalRepositoryFactory,
     GroupFactory, ArchivalCollectionFactory, FootnoteFactory,
-    LearningSiteRelationshipFactory)
+    LearningSiteRelationshipFactory, ExtendedDateFactory)
 from writlarge.main.views import (
-    django_settings, DigitalObjectCreateView, ConnectionCreateView)
+    django_settings, DigitalObjectCreateView, ConnectionCreateView, MapView)
 
 
 class BasicTest(TestCase):
@@ -744,3 +744,17 @@ class LearningSiteViewSetTest(TestCase):
         the_json = loads(response.content.decode('utf-8'))
         self.assertEquals(len(the_json), 1)
         self.assertEquals(the_json[0]['id'], site1.id)
+
+
+class MapViewTest(TestCase):
+
+    def test_get_min_year(self):
+        LearningSiteFactory(established=None, defunct=None)
+        LearningSiteFactory()
+
+        dt = ExtendedDateFactory(edtf_format='1918')
+        LearningSiteFactory(established=None, defunct=dt)
+
+        view = MapView()
+        qs = LearningSite.objects.all()
+        self.assertEquals(view.get_min_year(qs), 1918)

--- a/writlarge/main/views.py
+++ b/writlarge/main/views.py
@@ -1,3 +1,5 @@
+import datetime
+
 from django.conf import settings
 from django.contrib import messages
 from django.core.mail import send_mail
@@ -44,6 +46,20 @@ class CoverView(TemplateView):
 
 class MapView(TemplateView):
     template_name = "main/map.html"
+
+    def get_min_year(self, qs):
+        site = min(qs, key=lambda site: site.get_min_year() or float('inf'))
+        return site.get_min_year()
+
+    def get_context_data(self, *, object_list=None, **kwargs):
+        context = super(MapView, self).get_context_data(**kwargs)
+
+        qs = LearningSite.objects.filter().select_related(
+            'established', 'defunct')
+
+        context['min_year'] = self.get_min_year(qs)
+        context['max_year'] = datetime.date.today().year
+        return context
 
 
 class SearchView(LearningSiteSearchMixin, ListView):


### PR DESCRIPTION
* Calculate the minimum and maximum year for a LearningSite
* Add the minimum year in the LearningSite queryset to the MapView context
* Add the maximum year (today) to the MapView context

These data points will be used as input to a time filtering interface.