### PR TITLE
 Optimize search query components

### DIFF
--- a/media/js/src/components/familynetworkvue.js
+++ b/media/js/src/components/familynetworkvue.js
@@ -203,7 +203,7 @@ var FamilyNetworkVue = {
         }
     },
     created: function() {
-        const url = WritLarge.baseUrl + 'api/site/' +  this.siteid + '/';
+        const url = WritLarge.baseUrl + 'api/family/' +  this.siteid + '/';
         jQuery.getJSON(url, (data) => {
             this.nodes = data.family;
             this.nodes.unshift({

--- a/writlarge/main/models.py
+++ b/writlarge/main/models.py
@@ -338,17 +338,18 @@ class LearningSite(models.Model):
         category = self.category.first()
         return category.group if category else 'other'
 
-    def get_min_year(self):
-        if self.established:
-            return self.established.get_year()
-        if self.defunct:
-            return self.defunct.get_year()
+    def get_year_range(self):
+        est = self.established.get_year() if self.established else None
+        defunct = self.defunct.get_year() if self.defunct else None
 
-    def get_max_year(self):
-        if self.defunct:
-            return self.defunct.get_year()
-        if self.established:
-            return self.established.get_year()
+        if est and defunct:
+            return (est, defunct)
+        elif est:
+            return (est, est)
+        elif defunct:
+            return (defunct, defunct)
+        else:
+            return (None, None)
 
 
 class LearningSiteRelationship(models.Model):

--- a/writlarge/main/serializers.py
+++ b/writlarge/main/serializers.py
@@ -85,7 +85,7 @@ class LearningSiteSerializer(serializers.HyperlinkedModelSerializer):
         return instance
 
     def tags(self, obj):
-        return ', '.join(obj.tags.names())
+        return obj.tags.names()
 
 
 class LearningSiteFamilySerializer(serializers.HyperlinkedModelSerializer):

--- a/writlarge/main/tests/test_mixins.py
+++ b/writlarge/main/tests/test_mixins.py
@@ -28,7 +28,7 @@ class LearningSiteSearchMixinTest(TestCase):
         self.assertEquals(qs.count(), 1)
         self.assertEquals(qs.first(), self.site1)
 
-    def test_filter_years_only(self):
+    def test_filter_years_invalid(self):
         mixin = LearningSiteSearchMixin()
 
         mixin.request = RequestFactory().get(
@@ -36,6 +36,8 @@ class LearningSiteSearchMixinTest(TestCase):
         qs = mixin.filter(LearningSite.objects.all())
         self.assertEquals(qs.count(), 3)
 
+    def test_filter_years_valid_range(self):
+        mixin = LearningSiteSearchMixin()
         mixin.request = RequestFactory().get(
             '/', {'q': '', 'start': '1900', 'end': '1920'})
         qs = mixin.filter(LearningSite.objects.all())
@@ -43,6 +45,8 @@ class LearningSiteSearchMixinTest(TestCase):
         self.assertTrue(self.site2 in qs)
         self.assertTrue(self.site3 in qs)
 
+    def test_filter_years_valid_out_of_range(self):
+        mixin = LearningSiteSearchMixin()
         mixin.request = RequestFactory().get(
             '/', {'q': 'Alpha', 'start': '1900', 'end': '1920'})
         qs = mixin.filter(LearningSite.objects.all())

--- a/writlarge/main/tests/test_models.py
+++ b/writlarge/main/tests/test_models.py
@@ -208,21 +208,18 @@ class LearningSiteTest(TestCase):
         site = LearningSiteFactory()
         self.assertEquals(site.group(), 'school')
 
-    def test_get_min_max_year(self):
+    def test_get_year_range(self):
         site = LearningSiteFactory()
-        self.assertEquals(site.get_min_year(), 1984)
-        self.assertEquals(site.get_max_year(), 1984)
+        self.assertEquals(site.get_year_range(), (1984, 1984))
 
         site = LearningSiteFactory(established=None, defunct=None)
-        self.assertIsNone(site.get_min_year())
-        self.assertIsNone(site.get_max_year())
+        self.assertEquals(site.get_year_range(), (None, None))
 
         site = LearningSiteFactory()
         dt = ExtendedDate.objects.create(edtf_format='2018')
         site.defunct = dt
         site.save()
-        self.assertEquals(site.get_min_year(), 1984)
-        self.assertEquals(site.get_max_year(), 2018)
+        self.assertEquals(site.get_year_range(), (1984, 2018))
 
 
 class ArchivalCollectionSuggestionTest(TestCase):

--- a/writlarge/main/tests/test_views.py
+++ b/writlarge/main/tests/test_views.py
@@ -8,7 +8,7 @@ from django.urls.base import reverse
 from writlarge.main.forms import ConnectionForm
 from writlarge.main.models import (
     ArchivalCollection, LearningSite, ArchivalCollectionSuggestion)
-from writlarge.main.serializers import LearningSiteSerializer
+from writlarge.main.serializers import LearningSiteFamilySerializer
 from writlarge.main.tests.factories import (
     UserFactory, LearningSiteFactory, ArchivalRepositoryFactory,
     GroupFactory, ArchivalCollectionFactory, FootnoteFactory,
@@ -150,7 +150,7 @@ class ApiViewTest(TestCase):
         LearningSiteRelationshipFactory(site_one=parent, site_two=sib)
         LearningSiteRelationshipFactory(site_one=sib2, site_two=parent)
 
-        family = LearningSiteSerializer().get_family(parent)
+        family = LearningSiteFamilySerializer().get_family(parent)
         self.assertEquals(len(family), 2)
         self.assertEquals(family[0]['id'], sib.id)
         self.assertEquals(family[0]['relationship'], 'associate')

--- a/writlarge/main/views.py
+++ b/writlarge/main/views.py
@@ -27,7 +27,8 @@ from writlarge.main.models import (
     DigitalObject, ArchivalCollection, Footnote,
     ArchivalCollectionSuggestion)
 from writlarge.main.serializers import (
-    ArchivalRepositorySerializer, LearningSiteSerializer, PlaceSerializer)
+    ArchivalRepositorySerializer, LearningSiteSerializer, PlaceSerializer,
+    LearningSiteFamilySerializer)
 
 
 # returns important setting information for all web pages.
@@ -48,8 +49,9 @@ class MapView(TemplateView):
     template_name = "main/map.html"
 
     def get_min_year(self, qs):
-        site = min(qs, key=lambda site: site.get_min_year() or float('inf'))
-        return site.get_min_year()
+        site = min(
+            qs, key=lambda site: site.get_year_range()[0] or float('inf'))
+        return site.get_year_range()[0]
 
     def get_context_data(self, *, object_list=None, **kwargs):
         context = super(MapView, self).get_context_data(**kwargs)
@@ -462,6 +464,11 @@ class LearningSiteViewSet(LearningSiteSearchMixin, viewsets.ModelViewSet):
     def get_queryset(self):
         qs = LearningSite.objects.all()
         return self.filter(qs)
+
+
+class LearningSiteFamilyViewSet(viewsets.ModelViewSet):
+    queryset = LearningSite.objects.all()
+    serializer_class = LearningSiteFamilySerializer
 
 
 class PlaceViewSet(viewsets.ModelViewSet):

--- a/writlarge/templates/main/client/map_template.html
+++ b/writlarge/templates/main/client/map_template.html
@@ -76,7 +76,11 @@
 
                 <dl class="pin-detail-tags d-flex flex-row mb-0" v-if="selectedSite.tags">
                   <dt class="mr-1">Tags:</dt>
-                  <dd class="mb-0">{{selectedSite.tags}}</dd>
+                  <dd class="mb-0">
+                    <span v-for="(tag, idx) in tags">
+                        {{tag}}<span v-if="index + 1 < tags.length">,</span>
+                    </span>
+                  </dd>
                 </dl>
                 <div class="row mt-4 mt-md-3">
                     <div class="col">

--- a/writlarge/urls.py
+++ b/writlarge/urls.py
@@ -25,6 +25,7 @@ if hasattr(settings, 'CAS_BASE'):
 
 router = routers.DefaultRouter()
 router.register(r'site', views.LearningSiteViewSet, base_name='site')
+router.register(r'family', views.LearningSiteFamilyViewSet)
 router.register(r'repository', views.ArchivalRepositoryViewSet)
 router.register(r'place', views.PlaceViewSet)
 


### PR DESCRIPTION
The overall speed of filtering by dates is slow due to the ExtendedDate class, which does not store a real date in the database. This pushes range finding and searching into basic python, which can be slow. Long-term solutions include stashing a real date in the class or switching to Solr or ElasticSearch (the solution Footprints uses).

This PR does a myriad of things to speed up operations:
* optimizes database interaction via `prefetch_related` and `select_related`.
* minimizes access to the ExtendedDate attributes
* removes unnecessary fields from the serializers. (the `family` list is broken out to a separate serializer used exclusively for the connection visualization).
* swaps the slow serializers for `tags` to a straight array.