### PR TITLE
Secure Django HTTPS settings

### DIFF
--- a/writlarge/settings_production.py
+++ b/writlarge/settings_production.py
@@ -14,6 +14,9 @@ locals().update(
 #       s3static=False,
     ))
 
+CSRF_COOKIE_SECURE = True
+SESSION_COOKIE_SECURE = True
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.contrib.gis.db.backends.postgis',

--- a/writlarge/settings_staging.py
+++ b/writlarge/settings_staging.py
@@ -25,6 +25,9 @@ DATABASES = {
     }
 }
 
+CSRF_COOKIE_SECURE = True
+SESSION_COOKIE_SECURE = True
+
 try:
     from writlarge.local_settings import *
 except ImportError:


### PR DESCRIPTION
Per the Django deployment checklist: https://docs.djangoproject.com/en/2.1/howto/deployment/checklist/#https

To avoid transmitting the session cookie & csrf cookie accidentally over http, configure these to true.
```
CSRF_COOKIE_SECURE = True
SESSION_COOKIE_SECURE = True
```