### PR TITLE
ccnmtlsettings 1.8.0 - update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -78,7 +78,7 @@ django-storages==1.8
 
 djangorestframework==3.11.0
 
-ccnmtlsettings==1.6.0
+ccnmtlsettings==1.8.0
 
 django-reversion==3.0.5
 text_unidecode==1.3


### PR DESCRIPTION
the ccnmtlsettings bulk update did not work for this app as the match was attempted against 1.7.0. This app was still on 1.6.0.