### PR TITLE
Revert "⬆️ Bump cryptography from 3.3.2 to 3.4.7"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ fuzzywuzzy==0.18.0
 sure==1.4.11
 coverage==5.5
 pyasn1==0.4.8
-cryptography==3.3.2  # pyOpenSSL
+cryptography<3.3.2  # pyOpenSSL
 pyOpenSSL==20.0.1
 ndg-httpsclient==0.5.1
 urllib3==1.26.4  # requests, sentry-sdk

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ fuzzywuzzy==0.18.0
 sure==1.4.11
 coverage==5.5
 pyasn1==0.4.8
-cryptography==3.4.7  # pyOpenSSL
+cryptography==3.3.2  # pyOpenSSL
 pyOpenSSL==20.0.1
 ndg-httpsclient==0.5.1
 urllib3==1.26.4  # requests, sentry-sdk

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ fuzzywuzzy==0.18.0
 sure==1.4.11
 coverage==5.5
 pyasn1==0.4.8
-cryptography<3.3.2  # pyOpenSSL
+cryptography<=3.3.2  # pyOpenSSL
 pyOpenSSL==20.0.1
 ndg-httpsclient==0.5.1
 urllib3==1.26.4  # requests, sentry-sdk


### PR DESCRIPTION
Reverts ccnmtl/writlarge#1228