### PR TITLE
Paginate site retrieval

### DIFF
--- a/media/js/src/components/gmapvue.js
+++ b/media/js/src/components/gmapvue.js
@@ -1,5 +1,6 @@
 /* global google: true, enlargeBounds: true, lightGrayStyle: true */
-/* global Promise, getVisibleContentHeight, sanitize */
+/* global Promise, getVisibleContentHeight, sanitize, AsyncQueue */
+/* global parsePageNumber */
 /* exported GoogleMapVue */
 
 const GoogleMapVue = {
@@ -36,6 +37,9 @@ const GoogleMapVue = {
         }
     },
     methods: {
+        url: function(pageNumber) {
+            return WritLarge.baseUrl + 'api/site/?page=' + pageNumber;
+        },
         getSearchTerm: function() {
             return this.searchTerm;
         },
@@ -325,15 +329,37 @@ const GoogleMapVue = {
         searchByCategory: function(category) {
             this.searchTerm += ' category:' + category;
             this.search();
+        },
+        processData: function(data) {
+            this.sites = this.sites.concat(data.results);
+            const nextPage = parsePageNumber(data.next);
+            if (nextPage > 1) {
+                this.getPage(nextPage);
+            }
+        },
+        getData: function(params) {
+            return new Promise((resolve, reject) => {
+                $.ajax({
+                    type: 'GET',
+                    url: this.url(params.page),
+                    dataType: 'json',
+                    contentType: 'application/json',
+                    success: (data) => {
+                        resolve(data);
+                    },
+                    error: (error) => {
+                        reject(error);
+                    }
+                });
+            });
+        },
+        getPage: function(pageNumber) {
+            const ctx = {'page': pageNumber};
+            this.queue.add(this.getData, this.processData, ctx);
         }
     },
     created: function() {
-        if (this.showsites === 'true') {
-            const url = WritLarge.baseUrl + 'api/site/';
-            $.getJSON(url, (data) => {
-                this.sites = data;
-            });
-        }
+        this.queue = new AsyncQueue();
     },
     mounted: function() {
         let elt = document.getElementById(this.mapName);
@@ -399,6 +425,10 @@ const GoogleMapVue = {
 
         // eslint-disable-next-line scanjs-rules/call_addEventListener
         window.addEventListener('resize', this.resize);
+
+        if (this.showsites === 'true') {
+            this.getPage(1);
+        }
     },
     updated: function() {
         this.sites.forEach((site) => {

--- a/media/js/src/utils.js
+++ b/media/js/src/utils.js
@@ -1,7 +1,38 @@
 /* global google: true */
 /* exported csrfSafeMethod, enlargeBounds, lightGrayStyle */
 /* exported getVisibleContentHeight, sanitize */
+/* exported AsyncQueue, parsePageNumber */
 
+// Simplifying this approach
+// https://stackoverflow.com/questions/50498666/nodejs-async-promise-queue
+class AsyncQueue {
+    constructor() {
+        this.queue = [];
+        // eslint-disable-next-line scanjs-rules/call_setInterval
+        setInterval(this.resolveNext.bind(this), 100);
+    }
+    add(fn, cb, params) {
+        this.queue.push({fn, cb, params});
+    }
+    resolveNext() {
+        if (!this.queue.length) {
+            return;
+        }
+        const {fn, cb, params} = this.queue.shift();
+        fn(params).then(cb);
+    }
+}
+
+function parsePageNumber(str) {
+    let pageNumber = 1;
+    try {
+        let result = str.match(/page=(\d+)/);
+        pageNumber = parseInt(result[1], 10);
+    } catch (err) {
+        // continue with default page number
+    }
+    return pageNumber;
+}
 
 function csrfSafeMethod(method) {
     // these HTTP methods do not require CSRF protection

--- a/writlarge/main/tests/test_views.py
+++ b/writlarge/main/tests/test_views.py
@@ -97,14 +97,15 @@ class ApiViewTest(TestCase):
                                    HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         self.assertEquals(response.status_code, 200)
         the_json = loads(response.content.decode('utf-8'))
-        self.assertEquals(the_json[0]['id'], self.site.id)
+        self.assertEquals(len(the_json['results']), 1)
+        self.assertEquals(the_json['results'][0]['id'], self.site.id)
 
         response = self.client.get('/api/repository/', {},
                                    HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         self.assertEquals(response.status_code, 200)
 
         the_json = loads(response.content.decode('utf-8'))
-        self.assertEquals(the_json[0]['id'], self.repository.id)
+        self.assertEquals(the_json['results'][0]['id'], self.repository.id)
 
         # update fails
         response = self.client.post('/api/site/',
@@ -759,8 +760,8 @@ class LearningSiteViewSetTest(TestCase):
         response = self.client.get(url)
         self.assertEquals(response.status_code, 200)
         the_json = loads(response.content.decode('utf-8'))
-        self.assertEquals(len(the_json), 1)
-        self.assertEquals(the_json[0]['id'], site1.id)
+        self.assertEquals(len(the_json['results']), 1)
+        self.assertEquals(the_json['results'][0]['id'], site1.id)
 
 
 class MapViewTest(TestCase):

--- a/writlarge/settings_shared.py
+++ b/writlarge/settings_shared.py
@@ -78,7 +78,6 @@ INSTALLED_APPS += [  # noqa
     'rest_framework',
     'lti_provider',
     'edtf',
-    'debug_toolbar',
     'contactus'
 ]
 
@@ -92,7 +91,6 @@ TEMPLATES[0]['OPTIONS']['context_processors'].append(  # noqa
 MIDDLEWARE = [
     'django_statsd.middleware.GraphiteRequestTimingMiddleware',
     'django_statsd.middleware.GraphiteMiddleware',
-    'debug_toolbar.middleware.DebugToolbarMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -155,7 +153,10 @@ REST_FRAMEWORK = {
         'writlarge.main.utils.BrowsableAPIRendererNoForms'
     ),
     'PAGINATE_BY': 15,
-    'DATETIME_FORMAT': '%m/%d/%y %I:%M %p'
+    'DATETIME_FORMAT': '%m/%d/%y %I:%M %p',
+    'DEFAULT_PAGINATION_CLASS':
+        'rest_framework.pagination.PageNumberPagination',
+    'PAGE_SIZE': 15,
 }
 
 SESSION_COOKIE_SECURE = True


### PR DESCRIPTION
Rather than pulling all sites in one go, retrieve them in paginated format. This allows a progressive render and makes things feel speedier.